### PR TITLE
make sysdb a non singleton

### DIFF
--- a/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -33,7 +33,6 @@ public class SystemDatabase {
 
     private static Logger logger = LoggerFactory.getLogger(SystemDatabase.class) ;
     private DBOSConfig config ;
-    private static SystemDatabase instance ;
     private DataSource dataSource ;
     private WorkflowDAO workflowDAO;
     private StepsDAO stepsDAO ;
@@ -41,7 +40,7 @@ public class SystemDatabase {
     private NotificationService notificationService;
     private NotificationsDAO notificationsDAO ;
 
-    private SystemDatabase(DBOSConfig cfg) {
+    public SystemDatabase(DBOSConfig cfg) {
         config = cfg ;
         dataSource= SystemDatabase.createDataSource(config, null);
         stepsDAO = new StepsDAO(dataSource) ;
@@ -51,8 +50,7 @@ public class SystemDatabase {
         notificationsDAO = new NotificationsDAO(dataSource, stepsDAO, notificationService) ;
     }
 
-    private SystemDatabase(DataSource ds) {
-
+    public SystemDatabase(DataSource ds) {
         this.dataSource = ds ;
         workflowDAO = new WorkflowDAO(dataSource) ;
         stepsDAO = new StepsDAO(dataSource) ;
@@ -61,32 +59,8 @@ public class SystemDatabase {
         notificationsDAO = new NotificationsDAO(dataSource, stepsDAO, notificationService) ;
     }
 
-    public static synchronized void initialize(DBOSConfig cfg) {
-        if (instance != null) {
-            throw new IllegalStateException("SystemDatabase has already been initialized.");
-        }
-        instance = new SystemDatabase(cfg);
-    }
-
-    public static synchronized void initialize(DataSource ds) {
-        if (instance != null) {
-            throw new IllegalStateException("SystemDatabase has already been initialized.");
-        }
-        instance = new SystemDatabase(ds);
-    }
-
-    public static SystemDatabase getInstance() {
-        if (instance == null) {
-            throw new RuntimeException("SystemDatabase should be initalized first") ;
-        }
-        return instance ;
-    }
-
-    public synchronized static void destroy() {
-        if (instance.dataSource != null) {
-            ((HikariDataSource)instance.dataSource).close();
-        }
-        instance = null ;
+    public synchronized void destroy() {
+        ((HikariDataSource)dataSource).close();
     }
 
     public void setNotificationService(NotificationService service) {

--- a/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -35,13 +35,12 @@ class SystemDatabaseTest {
 
         DBUtils.recreateDB(dbosConfig);
         MigrationManager.runMigrations(dbosConfig);
-        SystemDatabase.initialize(dbosConfig);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dbosConfig);
     }
 
     @AfterAll
     static void onetimeTearDown() {
-        SystemDatabase.destroy();
+        systemDatabase.destroy();
     }
 
     @BeforeEach

--- a/src/test/java/dev/dbos/transact/execution/DBOSExecutorTest.java
+++ b/src/test/java/dev/dbos/transact/execution/DBOSExecutorTest.java
@@ -52,8 +52,7 @@ class DBOSExecutorTest {
     void setUp() throws SQLException{
         DBUtils.recreateDB(dbosConfig);
         DBOSExecutorTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();
@@ -408,8 +407,7 @@ class DBOSExecutorTest {
     void startDBOS() throws SQLException{
 
         DBOSExecutorTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/execution/RecoveryServiceTest.java
+++ b/src/test/java/dev/dbos/transact/execution/RecoveryServiceTest.java
@@ -53,8 +53,7 @@ class RecoveryServiceTest {
     void setUp() throws SQLException{
         DBUtils.recreateDB(dbosConfig);
         RecoveryServiceTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         recoveryService = new RecoveryService(dbosExecutor, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);

--- a/src/test/java/dev/dbos/transact/notifications/EventsTest.java
+++ b/src/test/java/dev/dbos/transact/notifications/EventsTest.java
@@ -53,8 +53,7 @@ public class EventsTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         EventsTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null) ;
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/notifications/NotificationServiceTest.java
+++ b/src/test/java/dev/dbos/transact/notifications/NotificationServiceTest.java
@@ -55,8 +55,7 @@ class NotificationServiceTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         NotificationServiceTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/queue/QueuesTest.java
+++ b/src/test/java/dev/dbos/transact/queue/QueuesTest.java
@@ -60,8 +60,7 @@ public class QueuesTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         dataSource = SystemDatabase.createDataSource(dbosConfig);
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         queueService = new QueueService(systemDatabase, dbosExecutor);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, queueService, null);

--- a/src/test/java/dev/dbos/transact/scheduled/SchedulerServiceTest.java
+++ b/src/test/java/dev/dbos/transact/scheduled/SchedulerServiceTest.java
@@ -53,8 +53,7 @@ class SchedulerServiceTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         SchedulerServiceTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         schedulerService = new SchedulerService(dbosExecutor);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, schedulerService);

--- a/src/test/java/dev/dbos/transact/step/StepsTest.java
+++ b/src/test/java/dev/dbos/transact/step/StepsTest.java
@@ -44,8 +44,7 @@ public class StepsTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         dataSource = SystemDatabase.createDataSource(dbosConfig);
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/workflow/AsyncWorkflowTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/AsyncWorkflowTest.java
@@ -51,8 +51,7 @@ public class AsyncWorkflowTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         AsyncWorkflowTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/workflow/QueueChildWorkflowTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/QueueChildWorkflowTest.java
@@ -55,8 +55,7 @@ public class QueueChildWorkflowTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         dataSource = SystemDatabase.createDataSource(dbosConfig);
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         queueService = new QueueService(systemDatabase, dbosExecutor);
 

--- a/src/test/java/dev/dbos/transact/workflow/SyncWorkflowTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/SyncWorkflowTest.java
@@ -46,8 +46,7 @@ public class SyncWorkflowTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         SyncWorkflowTest.dataSource = SystemDatabase.createDataSource(dbosConfig, null) ;
-        SystemDatabase.initialize(dataSource );
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         this.dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/workflow/TimeoutTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/TimeoutTest.java
@@ -53,8 +53,7 @@ public class TimeoutTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         TimeoutTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/workflow/UnifiedProxyTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/UnifiedProxyTest.java
@@ -51,8 +51,7 @@ public class UnifiedProxyTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         UnifiedProxyTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();

--- a/src/test/java/dev/dbos/transact/workflow/WorkflowMgmtTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/WorkflowMgmtTest.java
@@ -53,8 +53,7 @@ public class WorkflowMgmtTest {
     void beforeEachTest() throws SQLException {
         DBUtils.recreateDB(dbosConfig);
         WorkflowMgmtTest.dataSource = SystemDatabase.createDataSource(dbosConfig) ;
-        SystemDatabase.initialize(dataSource);
-        systemDatabase = SystemDatabase.getInstance();
+        systemDatabase = new SystemDatabase(dataSource);
         dbosExecutor = new DBOSExecutor(dbosConfig, systemDatabase);
         dbos = DBOS.initialize(dbosConfig, systemDatabase, dbosExecutor, null, null);
         dbos.launch();


### PR DESCRIPTION
Not sure we want to limit system database usage to a single instance per java application. In particular, I can think of scenarios where you might want to manage one DBOS applications from another via DBOS Client. Opening as draft as I'm not sure the broader opinion about this.