### PR TITLE
remove gradle/actions/setup-gradle from GH workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,9 +24,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Publish
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: publish
+        run: ./gradlew clean test
         env:
           # GitHub Packages credentials stored as repository secrets
           USERNAME: ${{ secrets.USERNAME_MAVEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          gradle-version: wrapper
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Wait for PostgreSQL
         run: |
@@ -46,9 +44,7 @@ jobs:
           PGPASSWORD: dbos
 
       - name: Run tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: clean test
+        run: ./gradlew clean test
         env:
           PGPASSWORD: dbos
 


### PR DESCRIPTION
from https://github.com/gradle/gradle-build-action?tab=readme-ov-file 

> As of `v3` this action has been superceded by `gradle/actions/setup-gradle`.
> Any workflow that uses `gradle/gradle-build-action@v3` will transparently delegate to `gradle/actions/setup-gradle@v3`.
>
> Users are encouraged to update their workflows, replacing:
> ```
> uses: gradle/gradle-build-action@v3
> ```
>
> with
> ```
> uses: gradle/actions/setup-gradle@v3
> ```
