### PR TITLE
SysDB Refactor

### DIFF
--- a/src/main/java/dev/dbos/transact/database/NotificationsDAO.java
+++ b/src/main/java/dev/dbos/transact/database/NotificationsDAO.java
@@ -12,11 +12,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.concurrent.TimeUnit;
 
-
+import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.zaxxer.hikari.HikariDataSource;
 
 public class NotificationsDAO {
 
@@ -174,7 +172,8 @@ public class NotificationsDAO {
             if (!hasExistingNotification) {
                 // Wait for the notification
                 // Support OAOO sleep
-                double actualTimeout = StepsDAO.sleep(dataSource, workflowUuid,
+                double actualTimeout = StepsDAO.sleep(dataSource,
+                        workflowUuid,
                         timeoutFunctionId,
                         timeoutSeconds,
                         true);
@@ -375,7 +374,8 @@ public class NotificationsDAO {
                 double actualTimeout = timeoutSeconds;
                 if (callerCtx != null) {
                     // Support OAOO sleep for workflows
-                    actualTimeout = StepsDAO.sleep(dataSource, callerCtx.getWorkflowId(),
+                    actualTimeout = StepsDAO.sleep(dataSource,
+                            callerCtx.getWorkflowId(),
                             callerCtx.getTimeoutFunctionId(),
                             timeoutSeconds,
                             true // skip_sleep

--- a/src/main/java/dev/dbos/transact/database/QueuesDAO.java
+++ b/src/main/java/dev/dbos/transact/database/QueuesDAO.java
@@ -13,11 +13,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
+import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.zaxxer.hikari.HikariDataSource;
 
 public class QueuesDAO {
     Logger logger = LoggerFactory.getLogger(QueuesDAO.class);

--- a/src/main/java/dev/dbos/transact/database/QueuesDAO.java
+++ b/src/main/java/dev/dbos/transact/database/QueuesDAO.java
@@ -219,7 +219,8 @@ public class QueuesDAO {
                     updatePs.addBatch();
                     retIds.add(id);
                 }
-                updatePs.executeBatch();
+                // TODO: should we be checking updateCounts?
+                int[] updateCounts = updatePs.executeBatch();
             }
 
             connection.commit();

--- a/src/main/java/dev/dbos/transact/database/StepsDAO.java
+++ b/src/main/java/dev/dbos/transact/database/StepsDAO.java
@@ -12,10 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.zaxxer.hikari.HikariDataSource;
 
 public class StepsDAO {
 
@@ -86,28 +85,25 @@ public class StepsDAO {
      * '_check_operation_execution_txn'.
      *
      * @param workflowId
-     *                     The UUID of the workflow.
+     *            The UUID of the workflow.
      * @param functionId
-     *                     The ID of the function/operation.
+     *            The ID of the function/operation.
      * @param functionName
-     *                     The expected name of the function/operation.
+     *            The expected name of the function/operation.
      * @param connection
-     *                     The active JDBC connection (corresponding to Python's
-     *                     'conn:
-     *                     sa.Connection').
+     *            The active JDBC connection (corresponding to Python's 'conn:
+     *            sa.Connection').
      * @return A {@link StepResult} object if the operation has completed, otherwise
      *         {@code null}.
      * @throws IllegalStateException
-     *                                    If the workflow does not exist in the
-     *                                    status table.
+     *             If the workflow does not exist in the status table.
      * @throws WorkflowCancelledException
-     *                                    If the workflow is in a cancelled status.
+     *             If the workflow is in a cancelled status.
      * @throws UnexpectedStepException
-     *                                    If the recorded function name for the
-     *                                    operation does not match
-     *                                    the provided name.
+     *             If the recorded function name for the operation does not match
+     *             the provided name.
      * @throws SQLException
-     *                                    For other database access errors.
+     *             For other database access errors.
      */
     public static StepResult checkStepExecutionTxn(String workflowId, int functionId, String functionName,
             Connection connection) throws SQLException, IllegalStateException,

--- a/src/main/java/dev/dbos/transact/database/StepsDAO.java
+++ b/src/main/java/dev/dbos/transact/database/StepsDAO.java
@@ -25,10 +25,6 @@ public class StepsDAO {
         this.dataSource = dataSource;
     }
 
-    public void recordStepResultTxn(StepResult result) throws SQLException {
-        StepsDAO.recordStepResultTxn(dataSource, result);
-    }
-
     public static void recordStepResultTxn(HikariDataSource dataSource, StepResult result) throws SQLException {
         if (dataSource.isClosed()) {
             throw new IllegalStateException("Database is closed!");

--- a/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -34,7 +34,7 @@ public class SystemDatabase implements AutoCloseable {
 
     private static Logger logger = LoggerFactory.getLogger(SystemDatabase.class);
     private final HikariDataSource dataSource;
-    
+
     private final WorkflowDAO workflowDAO;
     private final StepsDAO stepsDAO;
     private final QueuesDAO queuesDAO;
@@ -62,7 +62,6 @@ public class SystemDatabase implements AutoCloseable {
     public void stop() {
         notificationService.stop();
     }
-
 
     /**
      * Get workflow result by workflow ID

--- a/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -185,7 +185,7 @@ public class SystemDatabase implements AutoCloseable {
     public void recordStepResultTxn(StepResult result) {
 
         try {
-            stepsDAO.recordStepResultTxn(result);
+            StepsDAO.recordStepResultTxn(dataSource, result);
         } catch (SQLException sq) {
             logger.error("Unexpected SQL exception", sq);
             throw new DBOSException(UNEXPECTED.getCode(), sq.getMessage());
@@ -372,7 +372,7 @@ public class SystemDatabase implements AutoCloseable {
                     String jsonError = JSONUtil.serializeError(e);
                     StepResult r = new StepResult(ctx.getWorkflowId(), nextFuncId, functionName,
                             null, jsonError);
-                    stepsDAO.recordStepResultTxn(r);
+                    StepsDAO.recordStepResultTxn(dataSource, r);
                 }
 
                 if (e instanceof NonExistentWorkflowException) {
@@ -388,7 +388,7 @@ public class SystemDatabase implements AutoCloseable {
                 String jsonOutput = JSONUtil.serialize(functionResult);
                 StepResult o = new StepResult(ctx.getWorkflowId(), nextFuncId, functionName,
                         jsonOutput, null);
-                stepsDAO.recordStepResultTxn(o);
+                StepsDAO.recordStepResultTxn(dataSource, o);
             }
         } catch (SQLException sq) {
             throw new DBOSException(UNEXPECTED.getCode(),

--- a/src/main/java/dev/dbos/transact/database/WorkflowDAO.java
+++ b/src/main/java/dev/dbos/transact/database/WorkflowDAO.java
@@ -17,10 +17,9 @@ import java.sql.*;
 import java.time.Instant;
 import java.util.*;
 
+import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.zaxxer.hikari.HikariDataSource;
 
 public class WorkflowDAO {
 

--- a/src/main/java/dev/dbos/transact/database/WorkflowDAO.java
+++ b/src/main/java/dev/dbos/transact/database/WorkflowDAO.java
@@ -17,21 +17,25 @@ import java.sql.*;
 import java.time.Instant;
 import java.util.*;
 
-import javax.sql.DataSource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.zaxxer.hikari.HikariDataSource;
+
 public class WorkflowDAO {
 
-    private final DataSource dataSource;
+    private final HikariDataSource dataSource;
     private final Logger logger = LoggerFactory.getLogger(WorkflowDAO.class);
 
-    WorkflowDAO(DataSource ds) {
+    WorkflowDAO(HikariDataSource ds) {
         dataSource = ds;
     }
 
     public Optional<String> getWorkflowResult(String workflowId) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
+
         final String sql = "SELECT status, output, error " + "FROM dbos.workflow_status "
                 + "WHERE workflow_uuid = ?;";
 
@@ -69,6 +73,9 @@ public class WorkflowDAO {
 
     public WorkflowInitResult initWorkflowStatus(WorkflowStatusInternal initStatus,
             Integer maxRetries) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         try (Connection connection = dataSource.getConnection()) {
 
@@ -149,6 +156,9 @@ public class WorkflowDAO {
      */
     public InsertWorkflowResult insertWorkflowStatus(Connection connection,
             WorkflowStatusInternal status) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         String insertSQL = "INSERT INTO dbos.workflow_status ("
                 + "workflow_uuid, status, name, class_name, config_name, "
@@ -214,6 +224,9 @@ public class WorkflowDAO {
 
     public void updateWorkflowStatus(Connection connection, String workflowID, String status,
             UpdateWorkflowOptions options) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         StringBuilder setClauseBuilder = new StringBuilder("SET status = ?, updated_at = ?");
         StringBuilder whereClauseBuilder = new StringBuilder("WHERE workflow_uuid = ?");
@@ -309,6 +322,9 @@ public class WorkflowDAO {
      *            output serialized as json
      */
     public void recordWorkflowOutput(String workflowId, String result) {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         try {
             try (Connection connection = dataSource.getConnection()) {
@@ -336,6 +352,9 @@ public class WorkflowDAO {
      *            output serialized as json
      */
     public void recordWorkflowError(String workflowId, String error) {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         try {
             try (Connection connection = dataSource.getConnection()) {
@@ -352,6 +371,9 @@ public class WorkflowDAO {
     }
 
     public WorkflowStatus getWorkflowStatus(String workflowId) {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         try {
             ListWorkflowsInput input = new ListWorkflowsInput();
@@ -368,6 +390,9 @@ public class WorkflowDAO {
     }
 
     public List<WorkflowStatus> listWorkflows(ListWorkflowsInput input) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         List<WorkflowStatus> workflows = new ArrayList<>();
 
@@ -532,6 +557,9 @@ public class WorkflowDAO {
 
     public List<GetPendingWorkflowsOutput> getPendingWorkflows(String executorId, String appVersion)
             throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         String sqlTemplate = "SELECT workflow_uuid, queue_name " + "FROM %s.workflow_status "
                 + "WHERE status = ? " + "AND executor_id = ? " + "AND application_version = ?";
@@ -559,6 +587,9 @@ public class WorkflowDAO {
     }
 
     public Object awaitWorkflowResult(String workflowId) {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         final String sql = "SELECT status, output, error " + "FROM dbos.workflow_status "
                 + "WHERE workflow_uuid = ?";
@@ -614,6 +645,9 @@ public class WorkflowDAO {
                                                                      // child
             int functionId, // func id in the parent
             String functionName) {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         String sql = String.format(
                 "INSERT INTO %s.operation_outputs (workflow_uuid, function_id, function_name, child_workflow_id) "
@@ -645,6 +679,9 @@ public class WorkflowDAO {
 
     public Optional<String> checkChildWorkflow(String workflowUuid, int functionId)
             throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
         String sql = "SELECT child_workflow_id " + " FROM dbos.operation_outputs "
                 + "WHERE workflow_uuid = ? AND function_id = ? ";
 
@@ -667,6 +704,9 @@ public class WorkflowDAO {
     }
 
     public void cancelWorkflow(String workflowId) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         try (Connection conn = dataSource.getConnection()) {
 
@@ -707,6 +747,9 @@ public class WorkflowDAO {
     }
 
     public void resumeWorkflow(String workflowId) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         try (Connection connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);
@@ -741,6 +784,9 @@ public class WorkflowDAO {
 
     public String forkWorkflow(String originalWorkflowId, int startStep, ForkOptions options)
             throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
 
         String forkedWorkflowId = options.getForkedWorkflowId() == null
                 ? UUID.randomUUID().toString()
@@ -786,7 +832,7 @@ public class WorkflowDAO {
         }
     }
 
-    private void insertForkedWorkflowStatus(Connection connection, String forkedWorkflowId,
+    private static void insertForkedWorkflowStatus(Connection connection, String forkedWorkflowId,
             WorkflowStatus originalStatus, String applicationVersion, long timeoutMs)
             throws SQLException {
 
@@ -826,7 +872,7 @@ public class WorkflowDAO {
         }
     }
 
-    private void copyOperationOutputs(Connection connection, String originalWorkflowId,
+    private static void copyOperationOutputs(Connection connection, String originalWorkflowId,
             String forkedWorkflowId, int startStep) throws SQLException {
 
         String sql = "INSERT INTO dbos.operation_outputs ( "
@@ -851,7 +897,7 @@ public class WorkflowDAO {
      * forkWorkflow(originalWorkflowId, forkedWorkflowId, startStep, null); }
      */
 
-    private String getWorkflowStatus(Connection connection, String workflowId) throws SQLException {
+    private static String getWorkflowStatus(Connection connection, String workflowId) throws SQLException {
         String sql = "SELECT status FROM dbos.workflow_status WHERE workflow_uuid = ?";
 
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
@@ -866,7 +912,7 @@ public class WorkflowDAO {
         }
     }
 
-    private void updateWorkflowToEnqueued(Connection connection, String workflowId)
+    private static void updateWorkflowToEnqueued(Connection connection, String workflowId)
             throws SQLException {
         String sql = "UPDATE dbos.workflow_status " + " SET status = ?, " + " queue_name = ?, "
                 + " recovery_attempts = ?, " + " workflow_deadline_epoch_ms = 0, "
@@ -883,7 +929,7 @@ public class WorkflowDAO {
         }
     }
 
-    private Long getRowsCutoff(Connection connection, long rowsThreshold) throws SQLException {
+    private static Long getRowsCutoff(Connection connection, long rowsThreshold) throws SQLException {
         String sql = "SELECT created_at FROM dbos.workflow_status ORDER BY created_at DESC OFFSET ? LIMIT 1";
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setLong(1, rowsThreshold - 1);
@@ -898,6 +944,10 @@ public class WorkflowDAO {
     }
 
     public void garbageCollect(Long cutoffEpochTimestampMs, Long rowsThreshold) throws SQLException {
+        if (dataSource.isClosed()) {
+            throw new IllegalStateException("Database is closed!");
+        }
+
         try (Connection connection = dataSource.getConnection()) {
             if (rowsThreshold != null) {
                 Long rowsCutoff = getRowsCutoff(connection, rowsThreshold);

--- a/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -95,10 +95,7 @@ public class DBOSExecutor {
             this.appVersion = AppVersionComputer.computeAppVersion(registeredClasses);
         }
 
-        if (notificationService == null) {
-            notificationService = systemDatabase.getNotificationService();
-        }
-        notificationService.start();
+        systemDatabase.start();
     }
 
     public void shutdown() {
@@ -106,12 +103,10 @@ public class DBOSExecutor {
         // executorService.shutdownNow();
         // systemDatabase.destroy();
 
+        systemDatabase.stop();
+
         this.workflowMap = null;
         this.dbos = null;
-
-        if (notificationService != null) {
-            notificationService.stop();
-        }
     }
 
     public WorkflowFunctionWrapper getWorkflow(String workflowName) {

--- a/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -32,8 +32,8 @@ class SystemDatabaseTest {
     }
 
     @AfterAll
-    static void onetimeTearDown() {
-        systemDatabase.destroy();
+    static void onetimeTearDown() throws Exception {
+        systemDatabase.close();
     }
 
     @BeforeEach


### PR DESCRIPTION
While this PR leaves the SysDB functionality spread across multiple objects, it reduces interdependency by:

* SystemDatabase implements `AutoCloseable`
* using `HikariDataSource` instead of `DataSource` so that DAO objects can check the closed status before execution
* adds `start`/`stop` methods for managing `NotificationService` state so DBOSExecutor doesn't need a dependency on `NotificationService`.
* adds static `StepsDAO` methods to eliminate `StepsDAO` field in `NotificationsDAO` 