### PR TITLE
reduce default logging verbosity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,6 +122,10 @@ tasks.test {
 tasks.jar {
     archiveBaseName.set("transact")
     // Will produce: build/libs/transact-1.0.0.jar
+
+    manifest {
+        attributes["Implementation-Version"] = project.version.toString()
+    }
 }
 
 publishing {

--- a/src/main/java/dev/dbos/transact/Constants.java
+++ b/src/main/java/dev/dbos/transact/Constants.java
@@ -17,5 +17,5 @@ public class Constants {
   public static final String DBOS_INTERNAL_QUEUE = "_dbos_internal_queue";
   public static final String DBOS_SCHEDULER_QUEUE = "schedulerQueue";
 
-  public static final String JDBC_URL_ENV_VAR = "DBOS_SYSTEM_DATABASE_URL";
+  public static final String SYSTEM_JDBC_URL_ENV_VAR = "DBOS_SYSTEM_JDBC_URL";
 }

--- a/src/main/java/dev/dbos/transact/DBOS.java
+++ b/src/main/java/dev/dbos/transact/DBOS.java
@@ -244,7 +244,7 @@ public class DBOS {
   }
 
   public void launch() {
-    logger.debug("launch()");
+    logger.info("DBOS.launch()");
 
     if (dbosExecutor.get() == null) {
       var executor = new DBOSExecutor(config);
@@ -260,7 +260,7 @@ public class DBOS {
   }
 
   public void shutdown() {
-    logger.debug("shutdown()");
+    logger.info("DBOS.shutdown()");
 
     var current = dbosExecutor.getAndSet(null);
     if (current != null) {
@@ -339,7 +339,7 @@ public class DBOS {
    * @param value data that is published
    */
   public void setEvent(String key, Object value) {
-    logger.info("Received setEvent for key {}", key);
+    logger.debug("Received setEvent for key {}", key);
 
     var executor = dbosExecutor.get();
     if (executor == null) {
@@ -358,7 +358,7 @@ public class DBOS {
    * @return the published value or null
    */
   public Object getEvent(String workflowId, String key, float timeOut) {
-    logger.info("Received getEvent for {} {}", workflowId, key);
+    logger.debug("Received getEvent for {} {}", workflowId, key);
 
     var executor = dbosExecutor.get();
     if (executor == null) {

--- a/src/main/java/dev/dbos/transact/DBOS.java
+++ b/src/main/java/dev/dbos/transact/DBOS.java
@@ -244,7 +244,9 @@ public class DBOS {
   }
 
   public void launch() {
-    logger.info("DBOS.launch()");
+    var pkg = DBOS.class.getPackage();
+    var ver = pkg == null ? null : pkg.getImplementationVersion();
+    logger.info("Launching DBOS {}", ver == null ? "<unknown version>" : "v" + ver);
 
     if (dbosExecutor.get() == null) {
       var executor = new DBOSExecutor(config);
@@ -260,12 +262,12 @@ public class DBOS {
   }
 
   public void shutdown() {
-    logger.info("DBOS.shutdown()");
-
     var current = dbosExecutor.getAndSet(null);
     if (current != null) {
       current.close();
     }
+
+    logger.info("DBOS shut down");
   }
 
   /**

--- a/src/main/java/dev/dbos/transact/conductor/Conductor.java
+++ b/src/main/java/dev/dbos/transact/conductor/Conductor.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 
 public class Conductor implements AutoCloseable {
 
-  private static Logger logger = LoggerFactory.getLogger(Conductor.class);
+  private static final Logger logger = LoggerFactory.getLogger(Conductor.class);
   private static final Map<MessageType, BiFunction<Conductor, BaseMessage, BaseResponse>>
       dispatchMap;
 
@@ -189,7 +189,7 @@ public class Conductor implements AutoCloseable {
   }
 
   void setPingInterval() {
-    logger.info("setPingInterval");
+    logger.debug("setPingInterval");
 
     if (pingInterval != null) {
       pingInterval.cancel(false);
@@ -201,11 +201,10 @@ public class Conductor implements AutoCloseable {
                 return;
               }
               try {
-                logger.info("setPingInterval::scheduleAtFixedRate");
                 // Note, checking for null because websocket can connect before websocket
                 // variable is assigned
                 if (webSocket != null && !webSocket.isOutputClosed()) {
-                  logger.info("Sending ping to conductor");
+                  logger.debug("Sending ping to conductor");
 
                   webSocket
                       .sendPing(ByteBuffer.allocate(0))
@@ -228,10 +227,10 @@ public class Conductor implements AutoCloseable {
                           pingTimeoutMs,
                           TimeUnit.MILLISECONDS);
                 } else {
-                  logger.info("NOT Sending ping to conductor");
+                  logger.debug("NOT Sending ping to conductor");
                 }
               } catch (Exception e) {
-                logger.error("setPingInterval::scheduleAtFixedRate catch", e);
+                logger.error("setPingInterval::scheduleAtFixedRate", e);
               }
             },
             0,
@@ -315,7 +314,7 @@ public class Conductor implements AutoCloseable {
                     public CompletionStage<?> onClose(
                         WebSocket webSocket, int statusCode, String reason) {
                       if (isShutdown.get()) {
-                        logger.info("Shutdown Conductor connection");
+                        logger.debug("Shutdown Conductor connection");
                       } else if (reconnectTimeout == null) {
                         logger.warn("onClose: Connection to conductor lost. Reconnecting");
                         resetWebSocket();

--- a/src/main/java/dev/dbos/transact/config/DBOSConfig.java
+++ b/src/main/java/dev/dbos/transact/config/DBOSConfig.java
@@ -20,7 +20,7 @@ public record DBOSConfig(
     String appVersion,
     String executorId) {
 
-  static Logger logger = LoggerFactory.getLogger(DBOSConfig.class);
+  private static final Logger logger = LoggerFactory.getLogger(DBOSConfig.class);
 
   public static class Builder {
     private String appName;
@@ -105,15 +105,16 @@ public record DBOSConfig(
     public DBOSConfig build() {
       if (appName == null) throw new IllegalArgumentException("Name is required");
 
-      if (dbPassword == null) {
-        dbPassword = System.getenv(Constants.POSTGRES_PASSWORD_ENV_VAR);
-      }
       if (databaseUrl == null) {
-        databaseUrl = System.getenv(Constants.JDBC_URL_ENV_VAR);
-        logger.info("Using db_url env {}", databaseUrl);
+        databaseUrl = System.getenv(Constants.SYSTEM_JDBC_URL_ENV_VAR);
+        logger.debug("retrieved {} database url from {} env var", databaseUrl, Constants.SYSTEM_JDBC_URL_ENV_VAR);
+
       }
       if (dbUser == null) {
         dbUser = System.getenv(Constants.POSTGRES_USER_ENV_VAR);
+      }
+      if (dbPassword == null) {
+        dbPassword = System.getenv(Constants.POSTGRES_PASSWORD_ENV_VAR);
       }
 
       return new DBOSConfig(

--- a/src/main/java/dev/dbos/transact/context/DBOSContext.java
+++ b/src/main/java/dev/dbos/transact/context/DBOSContext.java
@@ -10,12 +10,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletableFuture;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class DBOSContext {
-
-  private static final Logger logger = LoggerFactory.getLogger(DBOSContext.class);
 
   // assigned context options
   String nextWorkflowId;

--- a/src/main/java/dev/dbos/transact/context/DBOSContextHolder.java
+++ b/src/main/java/dev/dbos/transact/context/DBOSContextHolder.java
@@ -1,13 +1,9 @@
 package dev.dbos.transact.context;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class DBOSContextHolder {
   // CB: I think this default ctor business will bite us.
   private static final ThreadLocal<DBOSContext> contextHolder =
       ThreadLocal.withInitial(DBOSContext::new);
-  private static Logger logger = LoggerFactory.getLogger(DBOSContextHolder.class);
 
   public static DBOSContext get() {
     return contextHolder.get();

--- a/src/main/java/dev/dbos/transact/database/DbRetry.java
+++ b/src/main/java/dev/dbos/transact/database/DbRetry.java
@@ -16,7 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class DbRetry {
-  private static final Logger log = LoggerFactory.getLogger(DbRetry.class);
+  private static final Logger logger = LoggerFactory.getLogger(DbRetry.class);
 
   private DbRetry() {}
 
@@ -81,7 +81,7 @@ public final class DbRetry {
         double jitterFactor = 0.5 + ThreadLocalRandom.current().nextDouble();
         long sleepMillis = Math.max(1L, (long) (backoff.toMillis() * jitterFactor));
 
-        log.warn(
+        logger.warn(
             "DB operation failed (attempt {} of {}): {}. Retrying in {} ms",
             attempt,
             opts.maxAttempts,

--- a/src/main/java/dev/dbos/transact/database/NotificationService.java
+++ b/src/main/java/dev/dbos/transact/database/NotificationService.java
@@ -22,7 +22,7 @@ public class NotificationService {
     public final Condition condition = lock.newCondition();
   }
 
-  Logger logger = LoggerFactory.getLogger(NotificationService.class);
+  private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 
   private final Map<String, LockConditionPair> notificationsMap = new ConcurrentHashMap<>();
   private volatile boolean running = false;
@@ -51,7 +51,7 @@ public class NotificationService {
       notificationListenerThread = new Thread(this::notificationListener, "NotificationListener");
       notificationListenerThread.setDaemon(true);
       notificationListenerThread.start();
-      logger.info("Notification listener started");
+      logger.debug("Notification listener started");
     }
   }
 
@@ -67,7 +67,7 @@ public class NotificationService {
     }
 
     notificationsMap.clear();
-    logger.info("Notification listener stopped");
+    logger.debug("Notification listener stopped");
   }
 
   private void notificationListener() {
@@ -107,7 +107,7 @@ public class NotificationService {
               } else if ("dbos_workflow_events_channel".equals(channel)) {
                 handleNotification(payload, "workflow_events");
               } else {
-                logger.error("Unknown channel: {}", channel);
+                logger.error("Unknown NOTIFY channel: {}", channel);
               }
             }
           }

--- a/src/main/java/dev/dbos/transact/database/NotificationsDAO.java
+++ b/src/main/java/dev/dbos/transact/database/NotificationsDAO.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class NotificationsDAO {
 
-  Logger logger = LoggerFactory.getLogger(NotificationsDAO.class);
+  private static final Logger logger = LoggerFactory.getLogger(NotificationsDAO.class);
   private HikariDataSource dataSource;
   private NotificationService notificationService;
 
@@ -67,8 +67,6 @@ public class NotificationsDAO {
             "INSERT INTO %s.notifications (destination_uuid, topic, message) VALUES (?, ?, ?) ";
 
         insertSql = String.format(insertSql, Constants.DB_SCHEMA);
-
-        logger.info(insertSql);
 
         try (PreparedStatement stmt = conn.prepareStatement(insertSql)) {
           stmt.setString(1, destinationUuid);
@@ -180,9 +178,6 @@ public class NotificationsDAO {
             StepsDAO.sleep(dataSource, workflowUuid, timeoutFunctionId, timeoutSeconds, true);
         long timeoutMs = (long) (actualTimeout * 1000);
         lockPair.condition.await(timeoutMs, TimeUnit.MILLISECONDS);
-
-      } else {
-        logger.info("We have notification. no need to sleep");
       }
     } finally {
       lockPair.lock.unlock();
@@ -401,7 +396,6 @@ public class NotificationsDAO {
           throw new RuntimeException("Interrupted while waiting for event", e);
         }
 
-        logger.debug("Awoken from await");
         // Read the value from the database after notification
         try (Connection conn = dataSource.getConnection();
             PreparedStatement stmt = conn.prepareStatement(getSql)) {

--- a/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 
 public class SystemDatabase implements AutoCloseable {
 
-  private static Logger logger = LoggerFactory.getLogger(SystemDatabase.class);
+  private static final Logger logger = LoggerFactory.getLogger(SystemDatabase.class);
   private final HikariDataSource dataSource;
 
   private final WorkflowDAO workflowDAO;
@@ -44,6 +44,8 @@ public class SystemDatabase implements AutoCloseable {
     notificationService = new NotificationService(dataSource);
     notificationsDAO = new NotificationsDAO(dataSource, notificationService);
   }
+
+
 
   @Override
   public void close() {

--- a/src/main/java/dev/dbos/transact/database/WorkflowDAO.java
+++ b/src/main/java/dev/dbos/transact/database/WorkflowDAO.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 public class WorkflowDAO {
 
   private final HikariDataSource dataSource;
-  private final Logger logger = LoggerFactory.getLogger(WorkflowDAO.class);
+  private static final Logger logger = LoggerFactory.getLogger(WorkflowDAO.class);
 
   WorkflowDAO(HikariDataSource ds) {
     dataSource = ds;
@@ -750,7 +750,7 @@ public class WorkflowDAO {
       if (currentStatus == null
           || WorkflowState.SUCCESS.name().equals(currentStatus)
           || WorkflowState.ERROR.name().equals(currentStatus)) {
-        logger.info("Returning without updating status");
+        logger.debug("Workflow {} already complete, aborting cancelWorkflow", workflowId);
         return;
       }
 
@@ -827,7 +827,7 @@ public class WorkflowDAO {
             ? UUID.randomUUID().toString()
             : options.forkedWorkflowId();
 
-    logger.info("forkWorkflow Original id {} forked id {}", originalWorkflowId, forkedWorkflowId);
+    logger.debug("forkWorkflow Original id {} forked id {}", originalWorkflowId, forkedWorkflowId);
 
     String applicationVersion = options.applicationVersion();
 

--- a/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -115,6 +115,9 @@ public class DBOSExecutor implements AutoCloseable {
         this.appVersion = AppVersionComputer.computeAppVersion(registeredClasses);
       }
 
+      logger.info("Executor ID: {}", this.executorId);
+      logger.info("Application Version: {}", this.appVersion);
+
       executorService = Executors.newCachedThreadPool();
       timeoutScheduler = Executors.newScheduledThreadPool(2);
 
@@ -153,6 +156,11 @@ public class DBOSExecutor implements AutoCloseable {
                 config.adminServerPort(), new AdminController(this, systemDatabase, queues));
         httpServer.start();
       }
+
+      logger.info("DBOS started");
+
+    } else {
+      logger.warn("DBOS Executor already started");
     }
   }
 

--- a/src/main/java/dev/dbos/transact/execution/RecoveryService.java
+++ b/src/main/java/dev/dbos/transact/execution/RecoveryService.java
@@ -35,10 +35,14 @@ public class RecoveryService {
       return;
     }
 
-    List<GetPendingWorkflowsOutput> workflows = new ArrayList<>();
-
-    workflows =
+    List<GetPendingWorkflowsOutput> workflows =
         systemDatabase.getPendingWorkflows(dbosExecutor.executorId(), dbosExecutor.appVersion());
+
+    if (workflows.size() > 0) {
+      logger.info("Recovering {} workflows for application version {}", workflows.size(), dbosExecutor.appVersion());
+    } else {
+      logger.info("No workflows to recover for application version {}", dbosExecutor.appVersion());
+    }
 
     final List<GetPendingWorkflowsOutput> toRecover = workflows;
     stopRequested = false;

--- a/src/main/java/dev/dbos/transact/execution/RecoveryService.java
+++ b/src/main/java/dev/dbos/transact/execution/RecoveryService.java
@@ -15,7 +15,7 @@ public class RecoveryService {
 
   private final SystemDatabase systemDatabase;
   private final DBOSExecutor dbosExecutor;
-  public Logger logger = LoggerFactory.getLogger(RecoveryService.class);
+  private static final Logger logger = LoggerFactory.getLogger(RecoveryService.class);
 
   private volatile boolean stopRequested = false;
   private Thread recoveryThread;
@@ -45,7 +45,7 @@ public class RecoveryService {
     recoveryThread = new Thread(() -> startupRecoveryThread(toRecover), "RecoveryService-Thread");
     recoveryThread.setDaemon(true);
     recoveryThread.start();
-    logger.info("Recovery service started");
+    logger.debug("Recovery service started");
   }
 
   /**
@@ -68,7 +68,7 @@ public class RecoveryService {
         logger.warn("Interrupted while stopping recovery thread", e);
       }
     }
-    logger.info("Recovery service stopped");
+    logger.debug("Recovery service stopped");
   }
 
   /**
@@ -79,7 +79,7 @@ public class RecoveryService {
     try {
       List<GetPendingWorkflowsOutput> pendingWorkflows = new CopyOnWriteArrayList<>(wToRecover);
 
-      logger.info("Starting recovery thread {} ", pendingWorkflows.size());
+      logger.debug("Starting recovery thread {} ", pendingWorkflows.size());
 
       while (!stopRequested && !pendingWorkflows.isEmpty()) {
         try {
@@ -99,7 +99,7 @@ public class RecoveryService {
             Thread.sleep(1000);
           } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
-            logger.info("Recovery thread interrupted during sleep");
+            logger.warn("Recovery thread interrupted during sleep");
             break;
           }
         } catch (Exception e) {
@@ -109,13 +109,13 @@ public class RecoveryService {
       }
 
       if (!stopRequested && pendingWorkflows.isEmpty()) {
-        logger.info("All pending workflows recovered successfully");
+        logger.debug("All pending workflows recovered successfully");
       }
 
     } catch (Exception e) {
       logger.error("Unexpected error during workflow recovery", e);
     } finally {
-      logger.info("Exiting recovery thread ");
+      logger.debug("Exiting recovery thread ");
     }
   }
 }

--- a/src/main/java/dev/dbos/transact/http/HttpServer.java
+++ b/src/main/java/dev/dbos/transact/http/HttpServer.java
@@ -18,7 +18,7 @@ public class HttpServer {
   private int port;
   private AdminController adminController;
 
-  Logger logger = LoggerFactory.getLogger(HttpServer.class);
+  private static final Logger logger = LoggerFactory.getLogger(HttpServer.class);
 
   private HttpServer(int port, AdminController ac) {
     this.port = port == 0 ? 3001 : port;

--- a/src/main/java/dev/dbos/transact/http/controllers/AdminController.java
+++ b/src/main/java/dev/dbos/transact/http/controllers/AdminController.java
@@ -61,7 +61,7 @@ public class AdminController {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public List<String> recovery(List<String> executorIds) {
-    logger.info("Recovering workflows for executors {}", executorIds);
+    logger.debug("Recovering workflows for executors {}", executorIds);
     List<WorkflowHandle<?, ?>> handles = dbosExecutor.recoverPendingWorkflows(executorIds);
     List<String> workflowIds = new ArrayList<>();
     for (WorkflowHandle<?, ?> handle : handles) {
@@ -121,7 +121,7 @@ public class AdminController {
   @Path("/workflows/{workflowId}")
   @Produces(MediaType.APPLICATION_JSON)
   public WorkflowStatus GetWorkflowStatus(@PathParam("workflowId") String workflowId) {
-    logger.info("Get workflow status for workflow {}", workflowId);
+    logger.debug("Get workflow status for workflow {}", workflowId);
     var status = systemDatabase.getWorkflowStatus(workflowId);
     return status.isEmpty() ? null : status.get();
   }
@@ -130,7 +130,7 @@ public class AdminController {
   @Path("/workflows/{workflowId}/steps")
   @Produces(MediaType.APPLICATION_JSON)
   public List<StepInfo> ListSteps(@PathParam("workflowId") String workflowId) {
-    logger.info("Retrieving steps for workflow {}", workflowId);
+    logger.debug("Retrieving steps for workflow {}", workflowId);
     return dbosExecutor.listWorkflowSteps(workflowId);
   }
 
@@ -138,7 +138,7 @@ public class AdminController {
   @Path("/workflows/{workflowId}/restart")
   @Produces(MediaType.APPLICATION_JSON)
   public ForkWorkflowResponse restart(@PathParam("workflowId") String workflowId) {
-    logger.info("Restarting workflow {} with a new ID", workflowId);
+    logger.debug("Restarting workflow {} with a new ID", workflowId);
     WorkflowHandle<?, ?> handle = dbosExecutor.forkWorkflow(workflowId, 0, null);
     return new ForkWorkflowResponse(handle.getWorkflowId());
   }
@@ -147,7 +147,7 @@ public class AdminController {
   @Path("/workflows/{workflowId}/resume")
   @Produces(MediaType.APPLICATION_JSON)
   public Response resume(@PathParam("workflowId") String workflowId) {
-    logger.info("Resuming workflow {}", workflowId);
+    logger.debug("Resuming workflow {}", workflowId);
     dbosExecutor.resumeWorkflow(workflowId);
     return Response.noContent().build();
   }
@@ -162,7 +162,7 @@ public class AdminController {
       request = new ForkWorkflowRequest();
     }
     int startStep = (request.startStep != null) ? request.startStep : 0;
-    logger.info("Forking workflow {} from step {} with a new ID", workflowId, startStep);
+    logger.debug("Forking workflow {} from step {} with a new ID", workflowId, startStep);
 
     Duration timeout = request.timeoutMs != null ? Duration.ofMillis(request.timeoutMs) : null;
     var options = new ForkOptions(request.newWorkflowId, request.applicationVersion, timeout);
@@ -174,7 +174,7 @@ public class AdminController {
   @POST
   @Path("/workflows/{workflowId}/cancel")
   public Response cancel(@PathParam("workflowId") String workflowId) {
-    logger.info("Cancel workflow {}", workflowId);
+    logger.debug("Cancel workflow {}", workflowId);
     dbosExecutor.cancelWorkflow(workflowId);
     return Response.noContent().build();
   }

--- a/src/main/java/dev/dbos/transact/internal/AppVersionComputer.java
+++ b/src/main/java/dev/dbos/transact/internal/AppVersionComputer.java
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory;
 
 public class AppVersionComputer {
 
-  static Logger logger = LoggerFactory.getLogger(AppVersionComputer.class);
+  private static Logger logger = LoggerFactory.getLogger(AppVersionComputer.class);
 
   public static String computeAppVersion(List<Class<?>> registeredClasses) {
     try {
@@ -25,6 +25,7 @@ public class AppVersionComputer {
 
       // Hash each unique class
       for (Class<?> clazz : sortedClasses) {
+        logger.debug("hashing {}", clazz.getName());
         String classHash = getClassBytecodeHash(clazz);
         hasher.update((clazz.getName() + ":" + classHash).getBytes("UTF-8"));
       }

--- a/src/main/java/dev/dbos/transact/internal/DBOSInvocationHandler.java
+++ b/src/main/java/dev/dbos/transact/internal/DBOSInvocationHandler.java
@@ -81,7 +81,7 @@ public class DBOSInvocationHandler implements InvocationHandler {
     }
 
     var name = step.name().isEmpty() ? method.getName() : step.name();
-    logger.info("Before : Executing step {}", name);
+    logger.debug("Before : Executing step {}", name);
     try {
       Object result =
           executor.runStepInternal(
@@ -91,7 +91,7 @@ public class DBOSInvocationHandler implements InvocationHandler {
               step.intervalSeconds(),
               step.backOffRate(),
               () -> method.invoke(target, args));
-      logger.info("After: Step completed successfully");
+      logger.debug("After: Step completed successfully");
       return result;
     } catch (Exception e) {
       logger.error("Step failed", e);

--- a/src/main/java/dev/dbos/transact/internal/QueueRegistry.java
+++ b/src/main/java/dev/dbos/transact/internal/QueueRegistry.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 public class QueueRegistry {
   private final ConcurrentHashMap<String, Queue> registry = new ConcurrentHashMap<>();
 
-  Logger logger = LoggerFactory.getLogger(QueueRegistry.class);
+  private static final Logger logger = LoggerFactory.getLogger(QueueRegistry.class);
 
   public void register(Queue queue) {
     var queueName = queue.name();

--- a/src/main/java/dev/dbos/transact/json/JSONUtil.java
+++ b/src/main/java/dev/dbos/transact/json/JSONUtil.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JSONUtil {
-  private static Logger logger = LoggerFactory.getLogger(Conductor.class);
+  private static final Logger logger = LoggerFactory.getLogger(Conductor.class);
 
   private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/dev/dbos/transact/migrations/MigrationManager.java
+++ b/src/main/java/dev/dbos/transact/migrations/MigrationManager.java
@@ -56,9 +56,9 @@ public class MigrationManager {
         throw new RuntimeException("Failed to check database", e);
       }
 
+      logger.info("Creating '{}' database", pair.database());
       try (Statement stmt = conn.createStatement()) {
         stmt.executeUpdate("CREATE DATABASE \"" + pair.database() + "\"");
-        logger.info("'{}' database created", pair.database());
       } catch (SQLException e) {
         throw new RuntimeException("Failed to create database", e);
       }
@@ -92,11 +92,10 @@ public class MigrationManager {
       Set<String> appliedMigrations = getAppliedMigrations(conn);
       List<MigrationFile> migrationFiles = loadMigrationFiles();
       for (MigrationFile migrationFile : migrationFiles) {
-        String filename = migrationFile.getFilename().toString();
-        logger.debug("processing migration file {}", filename);
-        String version = filename.split("_")[0];
+        String version = migrationFile.getFilename().split("_")[0];
 
         if (!appliedMigrations.contains(version)) {
+          logger.info("Applying migration file {}", migrationFile.getFilename());
           applyMigrationFile(conn, migrationFile.getSql());
           markMigrationApplied(conn, version);
         }

--- a/src/main/java/dev/dbos/transact/migrations/MigrationManager.java
+++ b/src/main/java/dev/dbos/transact/migrations/MigrationManager.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class MigrationManager {
 
-  static Logger logger = LoggerFactory.getLogger(MigrationManager.class);
+  private static final Logger logger = LoggerFactory.getLogger(MigrationManager.class);
   private final DataSource dataSource;
 
   public MigrationManager(DataSource dataSource) {
@@ -93,7 +93,7 @@ public class MigrationManager {
       List<MigrationFile> migrationFiles = loadMigrationFiles();
       for (MigrationFile migrationFile : migrationFiles) {
         String filename = migrationFile.getFilename().toString();
-        logger.info("processing migration file {}", filename);
+        logger.debug("processing migration file {}", filename);
         String version = filename.split("_")[0];
 
         if (!appliedMigrations.contains(version)) {

--- a/src/main/java/dev/dbos/transact/queue/QueueService.java
+++ b/src/main/java/dev/dbos/transact/queue/QueueService.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 public class QueueService {
 
-  Logger logger = LoggerFactory.getLogger(QueueService.class);
+  private static final Logger logger = LoggerFactory.getLogger(QueueService.class);
 
   private List<Queue> queues;
 
@@ -32,7 +32,7 @@ public class QueueService {
   }
 
   private void pollForWorkflows() {
-    logger.info("PollQueuesThread started {}", Thread.currentThread().getId());
+    logger.debug("PollQueuesThread started {}", Thread.currentThread().getId());
 
     double pollingInterval = 1.0;
     double minPollingInterval = 1.0;
@@ -86,7 +86,7 @@ public class QueueService {
 
     } finally {
       shutdownLatch.countDown();
-      logger.info("QueuesPollThread {} has ended. Exiting", Thread.currentThread().getId());
+      logger.debug("QueuesPollThread {} has ended. Exiting", Thread.currentThread().getId());
     }
   }
 
@@ -103,7 +103,7 @@ public class QueueService {
     this.queues = queues;
 
     if (running) {
-      logger.info("QueuesPollThread is already running.");
+      logger.warn("QueuesPollThread is already running.");
       return;
     }
 
@@ -112,14 +112,14 @@ public class QueueService {
     workerThread = new Thread(this::pollForWorkflows, "QueuesPollThread");
     workerThread.setDaemon(true);
     workerThread.start();
-    logger.info("QueuesPollThread started.");
+    logger.debug("QueuesPollThread started.");
   }
 
   public synchronized void stop() {
     logger.debug("stop() called");
 
     if (!running) {
-      logger.info("QueuesPollThread is not running.");
+      logger.warn("QueuesPollThread is not running.");
       return;
     }
     running = false;
@@ -143,7 +143,7 @@ public class QueueService {
     }
 
     this.queues = null;
-    logger.info("QueuePollThread stopped.");
+    logger.debug("QueuePollThread stopped.");
   }
 
   public synchronized boolean isStopped() {

--- a/src/main/java/dev/dbos/transact/scheduled/SchedulerService.java
+++ b/src/main/java/dev/dbos/transact/scheduled/SchedulerService.java
@@ -30,13 +30,13 @@ public class SchedulerService {
   public record ScheduledInstance(
       String className, String workflowName, Object instance, Cron cron) {}
 
-  private static Logger logger = LoggerFactory.getLogger(SchedulerService.class);
+  private static final Logger logger = LoggerFactory.getLogger(SchedulerService.class);
   private static final CronParser cronParser =
       new CronParser(CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ));
 
   public static ScheduledInstance makeScheduledInstance(
       String className, String workflowName, Object instance, String cronExpr) {
-    logger.info("Scheduling wf {}", workflowName);
+    logger.debug("Scheduling wf {}", workflowName);
     Cron cron = cronParser.parse(cronExpr);
     return new ScheduledInstance(className, workflowName, instance, cron);
   }
@@ -76,7 +76,7 @@ public class SchedulerService {
                 Object[] args = new Object[2];
                 args[0] = scheduledTime.toInstant();
                 args[1] = ZonedDateTime.now(ZoneOffset.UTC).toInstant();
-                logger.info("submitting to dbos Executor {}", wf.workflowName);
+                logger.debug("submitting to dbos Executor {}", wf.workflowName);
                 String workflowId =
                     String.format("sched-%s-%s", wf.workflowName, scheduledTime.toString());
                 var options =
@@ -88,13 +88,13 @@ public class SchedulerService {
               }
 
               if (!stop) {
-                logger.info("Scheduling the next execution");
+                logger.debug("Scheduling the next execution");
                 ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
                 executionTime
                     .nextExecution(now)
                     .ifPresent(
                         nextTime -> {
-                          logger.info("Next execution time {}", nextTime);
+                          logger.debug("Next execution time {}", nextTime);
                           long delayMs = Duration.between(now, nextTime).toMillis();
                           scheduler.schedule(this, delayMs, TimeUnit.MILLISECONDS);
                         });
@@ -117,7 +117,7 @@ public class SchedulerService {
   public void stop() {
     stop = true;
     List<Runnable> notRun = scheduler.shutdownNow();
-    logger.info("Shutting down scheduler service. Tasks not run {}", notRun.size());
+    logger.debug("Shutting down scheduler service. Tasks not run {}", notRun.size());
   }
 
   public void start() {

--- a/src/test/java/dev/dbos/transact/conductor/ConductorTest.java
+++ b/src/test/java/dev/dbos/transact/conductor/ConductorTest.java
@@ -61,7 +61,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(value = 2, unit = TimeUnit.MINUTES)
 public class ConductorTest {
 
-  static Logger logger = LoggerFactory.getLogger(ConductorTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(ConductorTest.class);
 
   SystemDatabase mockDB;
   DBOSExecutor mockExec;

--- a/src/test/java/dev/dbos/transact/conductor/TestWebSocketServer.java
+++ b/src/test/java/dev/dbos/transact/conductor/TestWebSocketServer.java
@@ -31,7 +31,7 @@ class TestWebSocketServer extends WebSocketServer {
     default void onClose(WebSocket conn, int code, String reason, boolean remote) {}
   }
 
-  private static Logger logger = LoggerFactory.getLogger(TestWebSocketServer.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestWebSocketServer.class);
   private WebSocketTestListener listener;
   private Semaphore startEvent = new Semaphore(0);
 

--- a/src/test/java/dev/dbos/transact/execution/RecoveryServiceTest.java
+++ b/src/test/java/dev/dbos/transact/execution/RecoveryServiceTest.java
@@ -40,7 +40,7 @@ class RecoveryServiceTest {
   private DBOSExecutor dbosExecutor;
   private ExecutingServiceImpl executingServiceImpl;
   private ExecutingService executingService;
-  Logger logger = LoggerFactory.getLogger(RecoveryServiceTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(RecoveryServiceTest.class);
 
   @BeforeAll
   public static void onetimeBefore() {

--- a/src/test/java/dev/dbos/transact/queue/QueuesTest.java
+++ b/src/test/java/dev/dbos/transact/queue/QueuesTest.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(value = 2, unit = TimeUnit.MINUTES)
 public class QueuesTest {
 
-  Logger logger = LoggerFactory.getLogger(QueuesTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(QueuesTest.class);
 
   private static DBOSConfig dbosConfig;
   private static DataSource dataSource;

--- a/src/test/java/dev/dbos/transact/utils/DBUtils.java
+++ b/src/test/java/dev/dbos/transact/utils/DBUtils.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class DBUtils {
 
-  public static Logger logger = LoggerFactory.getLogger(DBUtils.class);
+  private static final Logger logger = LoggerFactory.getLogger(DBUtils.class);
 
   public static void clearTables(DataSource ds) throws SQLException {
 

--- a/src/test/java/dev/dbos/transact/workflow/MgmtServiceImpl.java
+++ b/src/test/java/dev/dbos/transact/workflow/MgmtServiceImpl.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 
 public class MgmtServiceImpl implements MgmtService {
 
-  Logger logger = LoggerFactory.getLogger(MgmtServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(MgmtServiceImpl.class);
 
   private volatile int stepsExecuted;
   CountDownLatch mainThreadEvent;

--- a/src/test/java/dev/dbos/transact/workflow/QueueChildWorkflowTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/QueueChildWorkflowTest.java
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(value = 2, unit = TimeUnit.MINUTES)
 public class QueueChildWorkflowTest {
 
-  Logger logger = LoggerFactory.getLogger(QueuesTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(QueuesTest.class);
 
   private static DBOSConfig dbosConfig;
   private DBOS dbos;

--- a/src/test/java/dev/dbos/transact/workflow/SimpleServiceImpl.java
+++ b/src/test/java/dev/dbos/transact/workflow/SimpleServiceImpl.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 
 public class SimpleServiceImpl implements SimpleService {
 
-  Logger logger = LoggerFactory.getLogger(SimpleServiceImpl.class);
+  private static final Logger logger = LoggerFactory.getLogger(SimpleServiceImpl.class);
 
   private SimpleService simpleService;
 

--- a/src/test/java/dev/dbos/transact/workflow/WorkflowMgmtTest.java
+++ b/src/test/java/dev/dbos/transact/workflow/WorkflowMgmtTest.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 @Timeout(value = 2, unit = TimeUnit.MINUTES)
 public class WorkflowMgmtTest {
 
-  Logger logger = LoggerFactory.getLogger(WorkflowMgmtTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(WorkflowMgmtTest.class);
 
   private static DBOSConfig dbosConfig;
   private DBOS dbos;


### PR DESCRIPTION
Fixes #112

sample output from starter app in #109. Note, most of the noise at this point comes from the HikariDataSource we use to connect to PG. In the demo apps, I've set `logging.level.com.zaxxer.hikari` to ERROR, but I don't think we can/should do that by defaut in DBOS itself.

```
gw run
Reusing configuration cache.

> Task :app:run
SLF4J(W): Class path contains multiple SLF4J providers.
SLF4J(W): Found provider [ch.qos.logback.classic.spi.LogbackServiceProvider@108c4c35]
SLF4J(W): Found provider [org.slf4j.simple.SimpleServiceProvider@4ccabbaa]
SLF4J(W): See https://www.slf4j.org/codes.html#multiple_bindings for an explanation.
SLF4J(I): Actual provider is of type [ch.qos.logback.classic.spi.LogbackServiceProvider@108c4c35]
13:44:36.247 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-1 - Starting...
13:44:36.579 [main] INFO com.zaxxer.hikari.pool.HikariPool -- HikariPool-1 - Added connection org.postgresql.jdbc.PgConnection@16aa0a0a
13:44:36.582 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-1 - Start completed.
13:44:36.619 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-1 - Shutdown initiated...
13:44:36.623 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-1 - Shutdown completed.
13:44:36.624 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-2 - Starting...
13:44:36.662 [main] INFO com.zaxxer.hikari.pool.HikariPool -- HikariPool-2 - Added connection org.postgresql.jdbc.PgConnection@3c72f59f
13:44:36.663 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-2 - Start completed.
13:44:36.696 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-2 - Shutdown initiated...
13:44:36.697 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-2 - Shutdown completed.
13:44:36.709 [main] INFO dev.dbos.transact.DBOS -- DBOS.launch()
13:44:36.715 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-3 - Starting...
13:44:36.741 [main] INFO com.zaxxer.hikari.pool.HikariPool -- HikariPool-3 - Added connection org.postgresql.jdbc.PgConnection@470f1802
13:44:36.742 [main] INFO com.zaxxer.hikari.HikariDataSource -- HikariPool-3 - Start completed.
Step one completed!
Step two completed!
13:44:37.055 [main] INFO dev.dbos.transact.DBOS -- DBOS.shutdown()

BUILD SUCCESSFUL in 3s
2 actionable tasks: 2 executed
Configuration cache entry reused.
```