### PR TITLE
add manifest attributes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,6 +150,16 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
+tasks.jar {
+    manifest {
+        attributes["Implementation-Version"] = project.version
+        attributes["Implementation-Title"] = project.name
+        attributes["Implementation-Vendor"] = "DBOS, Inc"
+        attributes["Implementation-Vendor-Id"] = project.group
+        attributes["SCM-Revision"] = gitHash
+    }
+}
+
 tasks.test {
     useJUnitPlatform()
     testLogging {


### PR DESCRIPTION
Adds JAR manifest attributes. In particular, adds (back) `Implementation-Version` which is used when logging DBOS Launch

```java
      var pkg = DBOS.class.getPackage();
      var ver = pkg == null ? null : pkg.getImplementationVersion();
      logger.info("Launching DBOS {}", ver == null ? "<unknown version>" : "v" + ver);
```

