### PR TITLE
dsiable publish from release branch (for now)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   public:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/v')
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
We need to update how we handle patch versions from release branches. Disabling publish on the release 0.6 branch while we work on that