### PR TITLE
Add default logback.xml file that reduces Hikari log level

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,18 @@
 <configuration>
+
+    <!-- Suppress Hikari logs by default -->
     <logger name="com.zaxxer.hikari" level="WARN" />
 
+    <!-- Minimal console appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Root logger uses the console appender -->
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>
+
 </configuration>


### PR DESCRIPTION
fixes #136

Here's the log startup for the dbos-starter app w/ all the application.properties log level settings commented out:

```
> Task :bootRun

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/

 :: Spring Boot ::                (v3.5.5)

13:50:53.999 [restartedMain] INFO  c.e.d.DurableStarterApplication - Starting DurableStarterApplication using Java 17.0.16 with PID 115622 (/home/harry/apps/demo-apps/java/dbos-starter/build/classes/java/main started by harry in /home/harry/apps/demo-apps/java/dbos-starter)
13:50:54.002 [restartedMain] INFO  c.e.d.DurableStarterApplication - No active profile set, falling back to 1 default profile: "default"
13:50:54.035 [restartedMain] INFO  o.s.b.d.restart.ChangeableUrls - The Class-Path manifest attribute in /home/harry/.gradle/caches/modules-2/files-2.1/com.cronutils/cron-utils/9.2.1/5d3738bc7a2eaa45a94a76c6e87af54a95414637/cron-utils-9.2.1.jar referenced one or more files that do not exist: file:/home/harry/.gradle/caches/modules-2/files-2.1/com.cronutils/cron-utils/9.2.1/5d3738bc7a2eaa45a94a76c6e87af54a95414637/slf4j-api-2.0.7.jar
13:50:54.035 [restartedMain] INFO  o.s.b.d.e.DevToolsPropertyDefaultsPostProcessor - Devtools property defaults active! Set 'spring.devtools.add-properties' to 'false' to disable
13:50:54.035 [restartedMain] INFO  o.s.b.d.e.DevToolsPropertyDefaultsPostProcessor - For additional web related logging consider setting the 'logging.level.web' property to 'DEBUG'
13:50:54.732 [restartedMain] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat initialized with port 8080 (http)
13:50:54.740 [restartedMain] INFO  o.a.coyote.http11.Http11NioProtocol - Initializing ProtocolHandler ["http-nio-8080"]
13:50:54.742 [restartedMain] INFO  o.a.catalina.core.StandardService - Starting service [Tomcat]
13:50:54.742 [restartedMain] INFO  o.a.catalina.core.StandardEngine - Starting Servlet engine: [Apache Tomcat/10.1.44]
13:50:54.771 [restartedMain] INFO  o.a.c.c.C.[Tomcat].[localhost].[/] - Initializing Spring embedded WebApplicationContext
13:50:54.772 [restartedMain] INFO  o.s.b.w.s.c.ServletWebServerApplicationContext - Root WebApplicationContext: initialization completed in 736 ms
13:50:54.868 [restartedMain] INFO  o.s.b.a.w.s.WelcomePageHandlerMapping - Adding welcome page: class path resource [static/index.html]
13:50:55.041 [restartedMain] INFO  o.s.b.d.a.OptionalLiveReloadServer - LiveReload server is running on port 35729
13:50:55.211 [restartedMain] INFO  c.e.dbosstarter.config.DBOSLifecycle - Launch DBOS
13:50:55.212 [restartedMain] INFO  dev.dbos.transact.DBOS - Launching DBOS v0.7.0-a12-g51814ab
13:50:55.215 [restartedMain] INFO  d.d.transact.execution.DBOSExecutor - System Database: jdbc:postgresql://localhost:5432/dbos_starter_java
13:50:55.215 [restartedMain] INFO  d.d.transact.execution.DBOSExecutor - System Database User name: postgres
13:50:55.215 [restartedMain] INFO  d.d.transact.execution.DBOSExecutor - Executor ID: local
13:50:55.215 [restartedMain] INFO  d.d.transact.execution.DBOSExecutor - Application Version: 552067b4aac9aeeb2593031666af8de0af275d942cb691187bd855469595aa21
13:50:55.268 [restartedMain] INFO  d.d.t.execution.RecoveryService - No workflows to recover for application version 552067b4aac9aeeb2593031666af8de0af275d942cb691187bd855469595aa21
13:50:55.279 [restartedMain] INFO  d.d.transact.execution.DBOSExecutor - DBOS started
13:50:55.280 [restartedMain] INFO  o.a.coyote.http11.Http11NioProtocol - Starting ProtocolHandler ["http-nio-8080"]
13:50:55.293 [restartedMain] INFO  o.s.b.w.e.tomcat.TomcatWebServer - Tomcat started on port 8080 (http) with context path '/'
13:50:55.295 [restartedMain] INFO  c.e.d.config.AppStartedLogger - 🚀 DurableStarter Server is running on http://localhost:8080
13:50:55.302 [restartedMain] INFO  c.e.d.DurableStarterApplication - Started DurableStarterApplication in 1.588 seconds (process running for 1.976)
<==========---> 83% EXECUTING [3m 10s]
> :bootRun
```