### PR TITLE
Make all fields of all exceptions final

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSAwaitedWorkflowCancelledException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSAwaitedWorkflowCancelledException.java
@@ -8,7 +8,7 @@ package dev.dbos.transact.exceptions;
  * exception.
  */
 public class DBOSAwaitedWorkflowCancelledException extends RuntimeException {
-  private String workflowId;
+  private final String workflowId;
 
   public DBOSAwaitedWorkflowCancelledException(String workflowId) {
     super(String.format("Awaited workflow %s was cancelled.", workflowId));

--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSMaxRecoveryAttemptsExceededException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSMaxRecoveryAttemptsExceededException.java
@@ -6,14 +6,16 @@ package dev.dbos.transact.exceptions;
  */
 public class DBOSMaxRecoveryAttemptsExceededException extends RuntimeException {
 
-  private String workflowId;
-  private int maxRetries;
+  private final String workflowId;
+  private final int maxRetries;
 
   public DBOSMaxRecoveryAttemptsExceededException(String workflowId, int maxRetries) {
     super(
         String.format(
             "Workflow %s has been moved to the dead-letter queue after exceeding the maximum of %d retries",
             workflowId, maxRetries));
+    this.workflowId = workflowId;
+    this.maxRetries = maxRetries;
   }
 
   /**

--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSNonExistentWorkflowException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSNonExistentWorkflowException.java
@@ -8,7 +8,7 @@ package dev.dbos.transact.exceptions;
  * programmer error.
  */
 public class DBOSNonExistentWorkflowException extends RuntimeException {
-  private String workflowId;
+  private final String workflowId;
 
   public DBOSNonExistentWorkflowException(String workflowId) {
     super(String.format("Workflow does not exist %s", workflowId));

--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSSystemDatabaseException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSSystemDatabaseException.java
@@ -8,7 +8,7 @@ import java.sql.SQLException;
  * system database connectivity is restored.
  */
 public class DBOSSystemDatabaseException extends RuntimeException {
-  Throwable underlyingException;
+  private final Throwable underlyingException;
 
   public DBOSSystemDatabaseException(Throwable e) {
     super(

--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSWorkflowExecutionConflictException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSWorkflowExecutionConflictException.java
@@ -7,7 +7,7 @@ package dev.dbos.transact.exceptions;
  * execution should be abandoned, this exception should not be caught or otherwise handled.
  */
 public class DBOSWorkflowExecutionConflictException extends RuntimeException {
-  private String workflowId;
+  private final String workflowId;
 
   public DBOSWorkflowExecutionConflictException(String workflowId) {
     super("Conflicting workflow ID %s".formatted(workflowId));

--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSWorkflowFunctionNotFoundException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSWorkflowFunctionNotFoundException.java
@@ -8,8 +8,8 @@ package dev.dbos.transact.exceptions;
  * not exist.
  */
 public class DBOSWorkflowFunctionNotFoundException extends RuntimeException {
-  private String workflowId;
-  private String workflowName;
+  private final String workflowId;
+  private final String workflowName;
 
   public DBOSWorkflowFunctionNotFoundException(String id, String name) {
     super(String.format("Workflow function %s does not exist for workflow id %s.", name, id));


### PR DESCRIPTION
Some exceptions already have only `final` fields but some exceptions do not follow this convention.
`DBOSMaxRecoveryAttemptsExceededException` does not assign the fields.