### PR TITLE
Make JSON serde pluggable

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/json/JSONSerde.java
+++ b/transact/src/main/java/dev/dbos/transact/json/JSONSerde.java
@@ -1,0 +1,11 @@
+package dev.dbos.transact.json;
+
+public interface JSONSerde {
+  String serializeArray(Object[] args);
+
+  Object[] deserializeToArray(String json);
+
+  String toJson(Object obj);
+
+  <T> T fromJson(String content, Class<T> valueType);
+}

--- a/transact/src/main/java/dev/dbos/transact/json/JacksonJSONSerde.java
+++ b/transact/src/main/java/dev/dbos/transact/json/JacksonJSONSerde.java
@@ -1,0 +1,50 @@
+package dev.dbos.transact.json;
+
+import dev.dbos.transact.json.JSONUtil.JsonRuntimeException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class JacksonJSONSerde implements JSONSerde {
+  private final ObjectMapper mapper = new ObjectMapper();
+
+  {
+    mapper.registerModule(new JavaTimeModule());
+    mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // Optional
+  }
+
+  public String serializeArray(Object[] args) {
+    try {
+      return mapper.writeValueAsString(new Boxed(args));
+    } catch (JsonProcessingException e) {
+      throw new JsonRuntimeException(e);
+    }
+  }
+
+  public Object[] deserializeToArray(String json) {
+    try {
+      Boxed boxed = mapper.readValue(json, Boxed.class);
+      return boxed.args;
+    } catch (JsonProcessingException e) {
+      throw new JsonRuntimeException(e);
+    }
+  }
+
+  public String toJson(Object obj) {
+    try {
+      return mapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new JsonRuntimeException(e);
+    }
+  }
+
+  public <T> T fromJson(String content, Class<T> valueType) {
+    try {
+      return mapper.readValue(content, valueType);
+    } catch (JsonProcessingException e) {
+      throw new JsonRuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
I needed to register custom Jackson modules (Java8, Kotlin) and Mixins (For some other external library Classes which were not serializable by the default Jackson implementation). 

Also I might need to use the Micronaut Serde which is compatible with Jackson annotations and has the benefit of being GraalVM native compatible.

So I created this PR for your consideration.