### PR TITLE
Fix misused of inline step options (#254)

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -426,8 +426,8 @@ public class DBOSExecutor implements AutoCloseable {
           opts.name(),
           opts.retriesAllowed(),
           opts.maxAttempts(),
-          opts.backOffRate(),
           opts.intervalSeconds(),
+          opts.backOffRate(),
           childWfId,
           () -> {
             var res = stepfunc.execute();

--- a/transact/src/test/java/dev/dbos/transact/step/ServiceWFAndStep.java
+++ b/transact/src/test/java/dev/dbos/transact/step/ServiceWFAndStep.java
@@ -19,4 +19,6 @@ public interface ServiceWFAndStep {
   String stepWithLongRetry(String input) throws Exception;
 
   String stepRetryWorkflow(String input);
+
+  String inlineStepRetryWorkflow(String input);
 }

--- a/transact/src/test/java/dev/dbos/transact/step/ServiceWFAndStepImpl.java
+++ b/transact/src/test/java/dev/dbos/transact/step/ServiceWFAndStepImpl.java
@@ -135,4 +135,38 @@ public class ServiceWFAndStepImpl implements ServiceWFAndStep {
 
     return result;
   }
+
+  @Workflow(name = "inlineStepRetryTestWorkflow")
+  public String inlineStepRetryWorkflow(String input) {
+    long ctime = System.currentTimeMillis();
+    boolean caught = false;
+    String result = "2 Retries: ";
+    try {
+      result =
+          result
+              + DBOS.runStep(
+                  () -> {
+                    ++this.stepWithRetryRuns;
+                    throw new Exception("Will not ever run");
+                  },
+                  new StepOptions("inlineStepWithRetries")
+                      .withRetriesAllowed(true)
+                      .withMaxAttempts(2)
+                      .withIntervalSeconds(0.01)
+                      .withBackoffRate(2.0));
+      ;
+    } catch (Exception e) {
+      caught = true;
+    }
+    if (!caught) {
+      result += "<Step with retries should have thrown>";
+    }
+    if (System.currentTimeMillis() - ctime > 1000) {
+      result += "<Retry took too long>";
+    }
+    result += this.stepWithRetryRuns;
+    result += ".";
+
+    return result;
+  }
 }

--- a/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
+++ b/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
@@ -273,4 +273,21 @@ public class StepsTest {
     assertEquals(2, stepInfos.get(2).functionId());
     assertNull(stepInfos.get(2).error());
   }
+
+  @Test
+  public void inlineStepRetryLogic() throws Exception {
+    ServiceWFAndStep service =
+        DBOS.registerWorkflows(ServiceWFAndStep.class, new ServiceWFAndStepImpl());
+
+    DBOS.launch();
+
+    String workflowId = "wf-inlinestepretrytest-1234";
+    try (var id = new WorkflowOptions(workflowId).setContext()) {
+      service.inlineStepRetryWorkflow("input");
+    }
+
+    var handle = DBOS.retrieveWorkflow(workflowId);
+    String expectedRes = "2 Retries: 2.";
+    assertEquals(expectedRes, (String) handle.getResult());
+  }
 }


### PR DESCRIPTION
When an inline step is used, the ordering of the backoff rate and interval options is incorrect.

The newly added test shows the issue. The issue was not happening with an @Step.