### PR TITLE
DBOS.configure returns global instance

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/DBOS.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOS.java
@@ -785,7 +785,7 @@ public class DBOS {
    * Initializes the singleton instance of DBOS with config. Should be called once during app
    * startup, before launch. @DBOSConfig config dbos configuration
    */
-  public static void configure(DBOSConfig config) {
+  public static Instance configure(DBOSConfig config) {
     if (globalInstance.get() != null) {
       throw new IllegalStateException("DBOS is already configured");
     }
@@ -795,6 +795,9 @@ public class DBOS {
     if (!updated) {
       throw new IllegalStateException("DBOS is already configured");
     }
+
+    // TODO: https://github.com/dbos-inc/dbos-transact-java/issues/299
+    return globalInstance.get();
   }
 
   /**


### PR DESCRIPTION
reverts a breaking change from #291 where DBOS.config was void return instead of returning the global instance.

I think we should be keeping DBOS static and instnace APIs distinct, so returning the global instance from the static configure method seems wrong. However, this breaks a bunch of internal tests. So reverting until we understand the problem better is the right choice. Opened #299 to track fixing this