### PR TITLE
Update Scheduler WF ID

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -248,7 +248,7 @@ public class SchedulerService implements AutoCloseable {
                     return;
                   }
                   var args = new Object[] {nextTime.toInstant(), wfSchedule.context()};
-                  var workflowId = "sched-%s-%s".formatted(wfSchedule.scheduleName(), nextTime);
+                  var workflowId = "sched-%s-%s".formatted(wfSchedule.scheduleName(), nextTime.toOffsetDateTime());
                   logger.debug(
                       "Queuing scheduled workflow {} schedule {} workflowId {}",
                       regWorkflow.fullyQualifiedName(),
@@ -320,7 +320,7 @@ public class SchedulerService implements AutoCloseable {
                   return;
                 }
                 var args = new Object[] {scheduledTime.toInstant(), Instant.now()};
-                var workflowId = "sched-%s-%s".formatted(workflowName, scheduledTime);
+                var workflowId = "sched-%s-%s".formatted(workflowName, scheduledTime.toOffsetDateTime());
                 logger.debug(
                     "Triggering annotated workflow {} at {} workflowId {}",
                     workflowName,

--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -248,7 +248,9 @@ public class SchedulerService implements AutoCloseable {
                     return;
                   }
                   var args = new Object[] {nextTime.toInstant(), wfSchedule.context()};
-                  var workflowId = "sched-%s-%s".formatted(wfSchedule.scheduleName(), nextTime.toOffsetDateTime());
+                  var workflowId =
+                      "sched-%s-%s"
+                          .formatted(wfSchedule.scheduleName(), nextTime.toOffsetDateTime());
                   logger.debug(
                       "Queuing scheduled workflow {} schedule {} workflowId {}",
                       regWorkflow.fullyQualifiedName(),
@@ -320,7 +322,8 @@ public class SchedulerService implements AutoCloseable {
                   return;
                 }
                 var args = new Object[] {scheduledTime.toInstant(), Instant.now()};
-                var workflowId = "sched-%s-%s".formatted(workflowName, scheduledTime.toOffsetDateTime());
+                var workflowId =
+                    "sched-%s-%s".formatted(workflowName, scheduledTime.toOffsetDateTime());
                 logger.debug(
                     "Triggering annotated workflow {} at {} workflowId {}",
                     workflowName,

--- a/transact/src/test/java/dev/dbos/transact/scheduled/AnnotatedWorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/AnnotatedWorkflowScheduleTest.java
@@ -10,6 +10,8 @@ import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.Queue;
 
+import java.time.OffsetDateTime;
+
 import java.time.Duration;
 
 import com.zaxxer.hikari.HikariDataSource;
@@ -104,6 +106,33 @@ class AnnotatedWorkflowScheduleTest {
     System.out.println("Final count (1s do not ignore missed, after resume): " + count1dimb);
     assertTrue(count1dimb >= 10);
     assertTrue(count1dimb <= 14);
+  }
+
+  @Test
+  public void annotatedWorkflowIdUsesOffsetDateTimeFormat() throws Exception {
+    // Annotated scheduler IDs must use OffsetDateTime, not ZonedDateTime with zone brackets.
+    var q = new Queue("q2").withConcurrency(1);
+    dbos.registerQueue(q);
+    var impl = new AnnotatedScheduledServiceImpl(dbos);
+    dbos.registerProxy(AnnotatedScheduledService.class, impl);
+    dbos.launch();
+
+    Thread.sleep(3000);
+    DBOSTestAccess.getSchedulerService(dbos).close();
+
+    var workflows = dbos.listWorkflows(new ListWorkflowsInput().withWorkflowName("everySecond"));
+    assertFalse(workflows.isEmpty(), "Expected at least one everySecond execution");
+    for (var wf : workflows) {
+      var id = wf.workflowId();
+      assertFalse(id.contains("["), "Annotated workflow ID must not contain zone brackets: " + id);
+      // ID format: sched-{name}/{class}/-{offsetDateTime}
+      // The fully-qualified name ends with '/', so the timestamp starts two chars after the
+      // last '/' (skipping the trailing '-' separator).
+      var suffix = id.substring(id.lastIndexOf('/') + 2);
+      assertDoesNotThrow(
+          () -> OffsetDateTime.parse(suffix),
+          "Date suffix must be a valid OffsetDateTime: " + id);
+    }
   }
 
   @Test

--- a/transact/src/test/java/dev/dbos/transact/scheduled/AnnotatedWorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/AnnotatedWorkflowScheduleTest.java
@@ -10,9 +10,8 @@ import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.Queue;
 
-import java.time.OffsetDateTime;
-
 import java.time.Duration;
+import java.time.OffsetDateTime;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.AutoClose;
@@ -130,8 +129,7 @@ class AnnotatedWorkflowScheduleTest {
       // last '/' (skipping the trailing '-' separator).
       var suffix = id.substring(id.lastIndexOf('/') + 2);
       assertDoesNotThrow(
-          () -> OffsetDateTime.parse(suffix),
-          "Date suffix must be a valid OffsetDateTime: " + id);
+          () -> OffsetDateTime.parse(suffix), "Date suffix must be a valid OffsetDateTime: " + id);
     }
   }
 

--- a/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
@@ -6,11 +6,13 @@ import dev.dbos.transact.DBOS;
 import dev.dbos.transact.DBOSTestAccess;
 import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.utils.PgContainer;
+import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.ScheduleStatus;
 import dev.dbos.transact.workflow.WorkflowSchedule;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -595,6 +597,56 @@ class WorkflowScheduleTest {
     // At least 1 execution from trigger
     assertTrue(impl.counter >= 1, "Expected at least 1, got " + impl.counter);
     assertEquals("test-context", impl.lastContext);
+  }
+
+  // ── Workflow ID format ────────────────────────────────────────────────────
+
+  @Test
+  public void workflowIdUsesOffsetDateTimeFormat() throws Exception {
+    // Scheduler-generated IDs must use OffsetDateTime (e.g. 2026-04-20T10:15:30+00:00),
+    // not ZonedDateTime which appends zone name in brackets (e.g. [UTC]).
+    var impl = registerAndLaunch();
+    dbos.createSchedule(
+        new WorkflowSchedule("id-fmt-sched", "latchedRun", className(), "0/1 * * * * *"));
+
+    assertTrue(impl.latch.await(15, TimeUnit.SECONDS));
+
+    var prefix = "sched-id-fmt-sched-";
+    var workflows =
+        dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIdPrefix(prefix));
+    assertFalse(workflows.isEmpty());
+    for (var wf : workflows) {
+      var id = wf.workflowId();
+      assertFalse(id.contains("["), "Workflow ID must not contain zone name brackets: " + id);
+      assertDoesNotThrow(
+          () -> OffsetDateTime.parse(id.substring(prefix.length())),
+          "Date suffix must be a valid OffsetDateTime: " + id);
+    }
+  }
+
+  @Test
+  public void workflowIdIncludesTimezoneOffsetNotZoneName() throws Exception {
+    // When cronTimezone is a named zone (e.g. America/New_York), the ID must include the
+    // numeric offset (e.g. -04:00) but not the zone name in brackets.
+    var impl = registerAndLaunch();
+    dbos.createSchedule(
+        new WorkflowSchedule("tz-sched", "latchedRun", className(), "0/1 * * * * *")
+            .withCronTimezone(ZoneId.of("America/New_York")));
+
+    assertTrue(impl.latch.await(15, TimeUnit.SECONDS));
+
+    var prefix = "sched-tz-sched-";
+    var workflows =
+        dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIdPrefix(prefix));
+    assertFalse(workflows.isEmpty());
+    for (var wf : workflows) {
+      var id = wf.workflowId();
+      assertFalse(id.contains("["), "Workflow ID must not contain zone name brackets: " + id);
+      assertFalse(id.contains("America"), "Workflow ID must not contain zone name: " + id);
+      assertDoesNotThrow(
+          () -> OffsetDateTime.parse(id.substring(prefix.length())),
+          "Date suffix must be a valid OffsetDateTime: " + id);
+    }
   }
 
   // ── End-to-end ────────────────────────────────────────────────────────────

--- a/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
@@ -612,8 +612,7 @@ class WorkflowScheduleTest {
     assertTrue(impl.latch.await(15, TimeUnit.SECONDS));
 
     var prefix = "sched-id-fmt-sched-";
-    var workflows =
-        dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIdPrefix(prefix));
+    var workflows = dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIdPrefix(prefix));
     assertFalse(workflows.isEmpty());
     for (var wf : workflows) {
       var id = wf.workflowId();
@@ -636,8 +635,7 @@ class WorkflowScheduleTest {
     assertTrue(impl.latch.await(15, TimeUnit.SECONDS));
 
     var prefix = "sched-tz-sched-";
-    var workflows =
-        dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIdPrefix(prefix));
+    var workflows = dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIdPrefix(prefix));
     assertFalse(workflows.isEmpty());
     for (var wf : workflows) {
       var id = wf.workflowId();


### PR DESCRIPTION
Previously, scheduler used ZoneDateTime string format when creating workflow IDs, but this embeds the time zone ID in the workflow id. Example: `sched-run_every_min-2026-04-20T14:40-07:00[America/Los_Angeles]`. 

This PR uses OffsetDateTime in the workflow ID, which keeps the offset but drops the zone ID. Example:  `sched-run_every_min-2026-04-20T14:40-07:00`. 