### PR TITLE
validateNonWorkflowInvocation

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -1144,6 +1144,14 @@ public class DBOSExecutor implements AutoCloseable {
 
   // Workflow Execution Methods
 
+  // helper method to validate that @Workflow methods are not invoked from the startWorkflow lambda
+  public void validateNonWorkflowInvocation() {
+    var hook = hookHolder.get();
+    if (hook != null) {
+      throw new RuntimeException("Only @Workflow functions may run in this context");
+    }
+  }
+
   // execute a workflow via a proxy
   public Object runWorkflow(
       Object target, String instanceName, Method method, Object[] args, Workflow wfTag)

--- a/transact/src/main/java/dev/dbos/transact/internal/DBOSInvocationHandler.java
+++ b/transact/src/main/java/dev/dbos/transact/internal/DBOSInvocationHandler.java
@@ -57,15 +57,18 @@ public class DBOSInvocationHandler implements InvocationHandler {
     var implMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
     implMethod.setAccessible(true);
 
+    var executor = executor();
     var wfTag = implMethod.getAnnotation(Workflow.class);
     if (wfTag != null) {
-      return executor().runWorkflow(target, instanceName, implMethod, args, wfTag);
+      return executor.runWorkflow(target, instanceName, implMethod, args, wfTag);
     }
+
+    executor.validateNonWorkflowInvocation();
 
     var stepTag = implMethod.getAnnotation(Step.class);
     if (stepTag != null) {
       var options = StepOptions.create(stepTag, method);
-      return executor().runStep(() -> implMethod.invoke(target, args), options, null);
+      return executor.runStep(() -> implMethod.invoke(target, args), options, null);
     }
 
     return method.invoke(target, args);


### PR DESCRIPTION
Validate invocation capture is not enabled when invoking a non @Workflow method via DBOS Invocation handler

Note, using more generic terminology because #390  extends invocation capture to debouncer in addition to startWorkflow 

Fixes #376