### PR TITLE
SendBulk

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/DBOS.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOS.java
@@ -17,6 +17,7 @@ import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.QueueConflictResolution;
 import dev.dbos.transact.workflow.QueueOptions;
 import dev.dbos.transact.workflow.ScheduleStatus;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.SerializationStrategy;
 import dev.dbos.transact.workflow.Step;
 import dev.dbos.transact.workflow.StepInfo;
@@ -512,7 +513,7 @@ public class DBOS implements AutoCloseable {
       @NonNull Object message,
       @Nullable String topic,
       @Nullable String idempotencyKey) {
-    send(destinationId, message, topic, idempotencyKey, null);
+    send(destinationId, message, topic, idempotencyKey, null, false);
   }
 
   /**
@@ -523,7 +524,7 @@ public class DBOS implements AutoCloseable {
    * @param topic topic to which the message is send
    */
   public void send(@NonNull String destinationId, @NonNull Object message, @Nullable String topic) {
-    send(destinationId, message, topic, null, null);
+    send(destinationId, message, topic, null, null, false);
   }
 
   /**
@@ -541,8 +542,35 @@ public class DBOS implements AutoCloseable {
       @Nullable String topic,
       @Nullable String idempotencyKey,
       @Nullable SerializationStrategy serialization) {
+    send(destinationId, message, topic, idempotencyKey, serialization, false);
+  }
+
+  public void send(
+      @NonNull String destinationId,
+      @NonNull Object message,
+      @Nullable String topic,
+      @Nullable String idempotencyKey,
+      @Nullable SerializationStrategy serialization,
+      boolean sendToForks) {
     if (serialization == null) serialization = SerializationStrategy.DEFAULT;
-    ensureLaunched("send").send(destinationId, message, topic, idempotencyKey, serialization);
+    ensureLaunched("send")
+        .send(destinationId, message, topic, idempotencyKey, serialization, sendToForks);
+  }
+
+  public void sendBulk(@NonNull List<SendMessage> messages) {
+    sendBulk(messages, false, null);
+  }
+
+  public void sendBulk(@NonNull List<SendMessage> messages, boolean sendToForks) {
+    sendBulk(messages, sendToForks, null);
+  }
+
+  public void sendBulk(
+      @NonNull List<SendMessage> messages,
+      boolean sendToForks,
+      @Nullable SerializationStrategy serialization) {
+    if (serialization == null) serialization = SerializationStrategy.DEFAULT;
+    ensureLaunched("sendBulk").sendBulk(messages, sendToForks, serialization);
   }
 
   /**

--- a/transact/src/main/java/dev/dbos/transact/DBOS.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOS.java
@@ -131,7 +131,7 @@ public class DBOS implements AutoCloseable {
   /**
    * Register a lifecycle listener that receives callbacks when DBOS is launched or shut down
    *
-   * @param listener
+   * @param listener the lifecycle listener to register
    */
   private void registerLifecycleListener(@NonNull DBOSLifecycleListener listener) {
     if (dbosExecutor.get() != null) {
@@ -545,6 +545,17 @@ public class DBOS implements AutoCloseable {
     send(destinationId, message, topic, idempotencyKey, serialization, false);
   }
 
+  /**
+   * Send a message to a workflow with all options
+   *
+   * @param destinationId recipient of the message
+   * @param message message to be sent
+   * @param topic topic to which the message is sent
+   * @param idempotencyKey optional idempotency key for exactly-once send
+   * @param serialization serialization strategy to use (null for default)
+   * @param sendToForks if true, also deliver the message to any forked copies of the destination
+   *     workflow
+   */
   public void send(
       @NonNull String destinationId,
       @NonNull Object message,
@@ -557,14 +568,34 @@ public class DBOS implements AutoCloseable {
         .send(destinationId, message, topic, idempotencyKey, serialization, sendToForks);
   }
 
+  /**
+   * Send multiple messages to workflows using default options
+   *
+   * @param messages list of messages to send
+   */
   public void sendBulk(@NonNull List<SendMessage> messages) {
     sendBulk(messages, false, null);
   }
 
+  /**
+   * Send multiple messages to workflows
+   *
+   * @param messages list of messages to send
+   * @param sendToForks if true, also deliver each message to any forked copies of the destination
+   *     workflow
+   */
   public void sendBulk(@NonNull List<SendMessage> messages, boolean sendToForks) {
     sendBulk(messages, sendToForks, null);
   }
 
+  /**
+   * Send multiple messages to workflows with full options
+   *
+   * @param messages list of messages to send
+   * @param sendToForks if true, also deliver each message to any forked copies of the destination
+   *     workflow
+   * @param serialization serialization strategy to use (null for default)
+   */
   public void sendBulk(
       @NonNull List<SendMessage> messages,
       boolean sendToForks,

--- a/transact/src/main/java/dev/dbos/transact/DBOSClient.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOSClient.java
@@ -17,6 +17,7 @@ import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.QueueConflictResolution;
 import dev.dbos.transact.workflow.QueueOptions;
 import dev.dbos.transact.workflow.ScheduleStatus;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.SerializationStrategy;
 import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.Timeout;
@@ -647,7 +648,7 @@ public class DBOSClient implements AutoCloseable {
   }
 
   /** Options for sending a message. */
-  public record SendOptions(@Nullable SerializationStrategy serialization) {
+  public record SendOptions(@Nullable SerializationStrategy serialization, boolean sendToForks) {
     /**
      * Create SendOptions with default serialization strategy. Uses the system's default
      * serialization format for message encoding.
@@ -655,7 +656,7 @@ public class DBOSClient implements AutoCloseable {
      * @return SendOptions configured with default serialization
      */
     public static SendOptions defaults() {
-      return new SendOptions(SerializationStrategy.DEFAULT);
+      return new SendOptions(SerializationStrategy.DEFAULT, false);
     }
 
     /**
@@ -665,7 +666,11 @@ public class DBOSClient implements AutoCloseable {
      * @return SendOptions configured with portable JSON serialization
      */
     public static SendOptions portable() {
-      return new SendOptions(SerializationStrategy.PORTABLE);
+      return new SendOptions(SerializationStrategy.PORTABLE, false);
+    }
+
+    public SendOptions withSendToForks(boolean v) {
+      return new SendOptions(serialization, v);
     }
   }
 
@@ -705,8 +710,28 @@ public class DBOSClient implements AutoCloseable {
         (options != null && options.serialization() != null)
             ? options.serialization().formatName()
             : null;
+    boolean sendToForks = options != null && options.sendToForks();
 
-    systemDatabase.sendDirect(destinationId, message, topic, idempotencyKey, serializationFormat);
+    systemDatabase.sendBulk(
+        List.of(new SendMessage(destinationId, message, topic, idempotencyKey)),
+        null,
+        -1,
+        "DBOS.send",
+        sendToForks,
+        serializationFormat);
+  }
+
+  public void sendBulk(@NonNull List<SendMessage> messages) {
+    sendBulk(messages, null);
+  }
+
+  public void sendBulk(@NonNull List<SendMessage> messages, @Nullable SendOptions options) {
+    String serializationFormat =
+        (options != null && options.serialization() != null)
+            ? options.serialization().formatName()
+            : null;
+    boolean sendToForks = options != null && options.sendToForks();
+    systemDatabase.sendBulk(messages, null, -1, "DBOS.sendBulk", sendToForks, serializationFormat);
   }
 
   /**

--- a/transact/src/main/java/dev/dbos/transact/DBOSClient.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOSClient.java
@@ -120,6 +120,16 @@ public class DBOSClient implements AutoCloseable {
     this(url, user, password, schema, serializer, true);
   }
 
+  /**
+   * Construct a DBOSClient, by providing system database access credentials
+   *
+   * @param url System database JDBC URL
+   * @param user System database user
+   * @param password System database credential / password
+   * @param schema Database schema for DBOS tables
+   * @param serializer Custom serializer for serialization/deserialization
+   * @param useListenNotify if true, use PostgreSQL LISTEN/NOTIFY for real-time event notifications
+   */
   public DBOSClient(
       @NonNull String url,
       @NonNull String user,
@@ -565,6 +575,18 @@ public class DBOSClient implements AutoCloseable {
     }
   }
 
+  /**
+   * Enqueue a workflow with explicit serialization format and support for both positional and named
+   * arguments.
+   *
+   * @param <T> Return type of workflow function
+   * @param <E> Exception thrown by workflow function
+   * @param options {@link EnqueueOptions} for configuring the workflow enqueue
+   * @param positionalArgs Positional arguments to pass to the workflow function
+   * @param namedArgs Named arguments to pass to the workflow function (e.g., for Python kwargs)
+   * @param serializationFormat Serialization format string to use (null for default)
+   * @return WorkflowHandle for retrieving workflow ID, status, and results
+   */
   public <T, E extends Exception> @NonNull WorkflowHandle<T, E> enqueueWorkflow(
       @NonNull EnqueueOptions options,
       @Nullable Object[] positionalArgs,
@@ -669,6 +691,12 @@ public class DBOSClient implements AutoCloseable {
       return new SendOptions(SerializationStrategy.PORTABLE, false);
     }
 
+    /**
+     * Create a new SendOptions with the sendToForks flag set.
+     *
+     * @param v if true, deliver the message to any forked copies of the destination workflow
+     * @return new SendOptions with the sendToForks flag updated
+     */
     public SendOptions withSendToForks(boolean v) {
       return new SendOptions(serialization, v);
     }
@@ -721,10 +749,22 @@ public class DBOSClient implements AutoCloseable {
         serializationFormat);
   }
 
+  /**
+   * Send multiple messages to workflows using default options
+   *
+   * @param messages list of messages to send
+   */
   public void sendBulk(@NonNull List<SendMessage> messages) {
     sendBulk(messages, null);
   }
 
+  /**
+   * Send multiple messages to workflows with serialization options
+   *
+   * @param messages list of messages to send
+   * @param options optional send options including serialization type and fork delivery; null for
+   *     defaults
+   */
   public void sendBulk(@NonNull List<SendMessage> messages, @Nullable SendOptions options) {
     String serializationFormat =
         (options != null && options.serialization() != null)

--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -22,9 +22,9 @@ import dev.dbos.transact.workflow.GetWorkflowAggregatesInput;
 import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.NotificationInfo;
 import dev.dbos.transact.workflow.Queue;
-import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.QueueOptions;
 import dev.dbos.transact.workflow.ScheduleStatus;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.VersionInfo;
 import dev.dbos.transact.workflow.WorkflowAggregateRow;
@@ -466,34 +466,6 @@ public class SystemDatabase implements AutoCloseable {
         () ->
             NotificationsDAO.sendBulk(
                 ctx, messages, workflowId, stepId, functionName, sendToForks, serialization));
-  }
-
-  public void send(
-      String workflowId,
-      int stepId,
-      String destinationId,
-      Object message,
-      String topic,
-      String messageId,
-      String serialization) {
-    sendBulk(
-        List.of(new SendMessage(destinationId, message, topic, messageId)),
-        workflowId,
-        stepId,
-        "DBOS.send",
-        false,
-        serialization);
-  }
-
-  public void sendDirect(
-      String destinationId, Object message, String topic, String messageId, String serialization) {
-    sendBulk(
-        List.of(new SendMessage(destinationId, message, topic, messageId)),
-        null,
-        -1,
-        "DBOS.send",
-        false,
-        serialization);
   }
 
   public Object recv(

--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -22,6 +22,7 @@ import dev.dbos.transact.workflow.GetWorkflowAggregatesInput;
 import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.NotificationInfo;
 import dev.dbos.transact.workflow.Queue;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.QueueOptions;
 import dev.dbos.transact.workflow.ScheduleStatus;
 import dev.dbos.transact.workflow.StepInfo;
@@ -454,6 +455,19 @@ public class SystemDatabase implements AutoCloseable {
     return dbRetry(() -> WorkflowDAO.checkChildWorkflow(ctx, workflowUuid, functionId));
   }
 
+  public void sendBulk(
+      List<SendMessage> messages,
+      String workflowId,
+      int stepId,
+      String functionName,
+      boolean sendToForks,
+      String serialization) {
+    dbRetry(
+        () ->
+            NotificationsDAO.sendBulk(
+                ctx, messages, workflowId, stepId, functionName, sendToForks, serialization));
+  }
+
   public void send(
       String workflowId,
       int stepId,
@@ -462,18 +476,24 @@ public class SystemDatabase implements AutoCloseable {
       String topic,
       String messageId,
       String serialization) {
-    dbRetry(
-        () ->
-            NotificationsDAO.send(
-                ctx, workflowId, stepId, destinationId, message, topic, messageId, serialization));
+    sendBulk(
+        List.of(new SendMessage(destinationId, message, topic, messageId)),
+        workflowId,
+        stepId,
+        "DBOS.send",
+        false,
+        serialization);
   }
 
   public void sendDirect(
       String destinationId, Object message, String topic, String messageId, String serialization) {
-    dbRetry(
-        () ->
-            NotificationsDAO.sendDirect(
-                ctx, destinationId, message, topic, messageId, serialization));
+    sendBulk(
+        List.of(new SendMessage(destinationId, message, topic, messageId)),
+        null,
+        -1,
+        "DBOS.send",
+        false,
+        serialization);
   }
 
   public Object recv(

--- a/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
@@ -1,5 +1,7 @@
 package dev.dbos.transact.database.dao;
 
+import static java.util.stream.Collectors.joining;
+
 import dev.dbos.transact.Constants;
 import dev.dbos.transact.database.DbContext;
 import dev.dbos.transact.database.GetEventCaller;
@@ -32,8 +34,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import static java.util.stream.Collectors.joining;
-
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -57,7 +57,8 @@ public class NotificationsDAO {
           """
           SELECT workflow_uuid, forked_from FROM "%s".workflow_status
           WHERE forked_from IN (%s)
-          """.formatted(schema, placeholders);
+          """
+              .formatted(schema, placeholders);
       try (var stmt = conn.prepareStatement(sql)) {
         for (int i = 0; i < frontier.size(); i++) stmt.setString(i + 1, frontier.get(i));
         List<String> next = new ArrayList<>();
@@ -104,11 +105,7 @@ public class NotificationsDAO {
     }
 
     // Reject duplicate idempotency keys within the batch
-    var keys =
-        messages.stream()
-            .map(SendMessage::idempotencyKey)
-            .filter(Objects::nonNull)
-            .toList();
+    var keys = messages.stream().map(SendMessage::idempotencyKey).filter(Objects::nonNull).toList();
     if (keys.size() != keys.stream().distinct().count()) {
       throw new IllegalArgumentException("Duplicate idempotency keys within sendBulk batch");
     }
@@ -120,7 +117,9 @@ public class NotificationsDAO {
     record SerializedPair(SendMessage msg, SerializationUtil.SerializedResult serialized) {}
     List<SerializedPair> pairs = new ArrayList<>(messages.size());
     for (var msg : messages) {
-      pairs.add(new SerializedPair(msg, SerializationUtil.serializeValue(msg.message(), serialization, serializer)));
+      pairs.add(
+          new SerializedPair(
+              msg, SerializationUtil.serializeValue(msg.message(), serialization, serializer)));
     }
 
     try (Connection conn = ctx.getConnection()) {
@@ -140,12 +139,17 @@ public class NotificationsDAO {
         // Collect all destination IDs for fork resolution
         Map<String, Set<String>> forkDescendants = Map.of();
         if (sendToForks) {
-          List<String> destIds = pairs.stream().map(p -> p.msg().destinationId()).distinct().toList();
+          List<String> destIds =
+              pairs.stream().map(p -> p.msg().destinationId()).distinct().toList();
           forkDescendants = findForkDescendantsTxn(conn, ctx.schema(), destIds);
         }
 
         // Build insert rows: base dest + sorted descendants
-        record InsertRow(String destId, SerializationUtil.SerializedResult serialized, String topic, String messageUuid) {}
+        record InsertRow(
+            String destId,
+            SerializationUtil.SerializedResult serialized,
+            String topic,
+            String messageUuid) {}
         List<InsertRow> rows = new ArrayList<>();
         for (var pair : pairs) {
           var msg = pair.msg();
@@ -177,7 +181,8 @@ public class NotificationsDAO {
                 (destination_uuid, topic, message, serialization, message_uuid)
               VALUES (?, ?, ?, ?, ?)
               ON CONFLICT (message_uuid) DO NOTHING
-            """.formatted(ctx.schema());
+            """
+                .formatted(ctx.schema());
 
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
           for (var row : rows) {
@@ -200,7 +205,8 @@ public class NotificationsDAO {
 
         if (workflowId != null) {
           var output = new StepResult(workflowId, stepId, functionName, null, null, null, null);
-          StepsDAO.recordStepResult(conn, ctx.schema(), output, startTime, System.currentTimeMillis());
+          StepsDAO.recordStepResult(
+              conn, ctx.schema(), output, startTime, System.currentTimeMillis());
         }
 
         conn.commit();

--- a/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
@@ -164,13 +164,11 @@ public class NotificationsDAO {
           }
 
           for (String dest : destinations) {
-            String uuid;
-            if (msg.idempotencyKey() != null) {
-              uuid = sendToForks ? msg.idempotencyKey() + "::" + dest : msg.idempotencyKey();
-            } else {
-              uuid = UUID.randomUUID().toString();
-            }
-            rows.add(new InsertRow(dest, pair.serialized(), finalTopic, uuid));
+            var wfid =
+                msg.idempotencyKey() != null
+                    ? msg.idempotencyKey() + "::" + dest
+                    : UUID.randomUUID().toString();
+            rows.add(new InsertRow(dest, pair.serialized(), finalTopic, wfid));
           }
         }
 

--- a/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
@@ -10,6 +10,7 @@ import dev.dbos.transact.exceptions.DBOSNonExistentWorkflowException;
 import dev.dbos.transact.json.DBOSSerializer;
 import dev.dbos.transact.json.SerializationUtil;
 import dev.dbos.transact.workflow.NotificationInfo;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.internal.StepResult;
 
 import java.sql.Connection;
@@ -18,11 +19,20 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+
+import static java.util.stream.Collectors.joining;
 
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -35,77 +45,165 @@ public class NotificationsDAO {
 
   private static final Logger logger = LoggerFactory.getLogger(NotificationsDAO.class);
 
-  public static void send(
+  private static Map<String, Set<String>> findForkDescendantsTxn(
+      Connection conn, String schema, List<String> workflowIds) throws SQLException {
+    Map<String, List<String>> children = new HashMap<>();
+    Set<String> seen = new LinkedHashSet<>(workflowIds);
+    List<String> frontier = new ArrayList<>(new LinkedHashSet<>(workflowIds));
+
+    while (!frontier.isEmpty()) {
+      String placeholders = frontier.stream().map(x -> "?").collect(joining(","));
+      String sql =
+          """
+          SELECT workflow_uuid, forked_from FROM "%s".workflow_status
+          WHERE forked_from IN (%s)
+          """.formatted(schema, placeholders);
+      try (var stmt = conn.prepareStatement(sql)) {
+        for (int i = 0; i < frontier.size(); i++) stmt.setString(i + 1, frontier.get(i));
+        List<String> next = new ArrayList<>();
+        try (var rs = stmt.executeQuery()) {
+          while (rs.next()) {
+            String forkedId = rs.getString("workflow_uuid");
+            String forkedFrom = rs.getString("forked_from");
+            children.computeIfAbsent(forkedFrom, k -> new ArrayList<>()).add(forkedId);
+            if (seen.add(forkedId)) next.add(forkedId);
+          }
+        }
+        frontier = next;
+      }
+    }
+
+    Map<String, Set<String>> result = new LinkedHashMap<>();
+    for (String root : workflowIds) {
+      if (result.containsKey(root)) continue;
+      Set<String> descendants = new LinkedHashSet<>();
+      Deque<String> stack = new ArrayDeque<>(children.getOrDefault(root, List.of()));
+      while (!stack.isEmpty()) {
+        String node = stack.pop();
+        if (!node.equals(root) && descendants.add(node)) {
+          stack.addAll(children.getOrDefault(node, List.of()));
+        }
+      }
+      result.put(root, descendants);
+    }
+    return result;
+  }
+
+  public static void sendBulk(
       DbContext ctx,
+      List<SendMessage> messages,
       String workflowId,
       int stepId,
-      String destinationId,
-      Object message,
-      String topic,
-      String messageId,
+      String functionName,
+      boolean sendToForks,
       String serialization)
       throws SQLException {
 
+    if (messages.isEmpty()) {
+      return;
+    }
+
+    // Reject duplicate idempotency keys within the batch
+    var keys =
+        messages.stream()
+            .map(SendMessage::idempotencyKey)
+            .filter(Objects::nonNull)
+            .toList();
+    if (keys.size() != keys.stream().distinct().count()) {
+      throw new IllegalArgumentException("Duplicate idempotency keys within sendBulk batch");
+    }
+
     DBOSSerializer serializer = ctx.serializer();
     var startTime = System.currentTimeMillis();
-    String functionName = "DBOS.send";
-    String finalTopic = (topic != null) ? topic : Constants.DBOS_NULL_TOPIC;
+
+    // Serialize each message once
+    record SerializedPair(SendMessage msg, SerializationUtil.SerializedResult serialized) {}
+    List<SerializedPair> pairs = new ArrayList<>(messages.size());
+    for (var msg : messages) {
+      pairs.add(new SerializedPair(msg, SerializationUtil.serializeValue(msg.message(), serialization, serializer)));
+    }
 
     try (Connection conn = ctx.getConnection()) {
       conn.setAutoCommit(false);
-
       try {
-        StepResult recordedOutput =
-            StepsDAO.checkStepResult(conn, ctx.schema(), workflowId, stepId, functionName);
-
-        if (recordedOutput != null) {
-          logger.debug(
-              "Replaying send, id: {}, destination_uuid: {}, topic: {}",
-              stepId,
-              destinationId,
-              finalTopic);
-          conn.commit();
-          return;
-        } else {
-          logger.debug(
-              "Running send, id: {}, destination_uuid: {}, topic: {}",
-              stepId,
-              destinationId,
-              finalTopic);
+        // Check for replay if inside a workflow
+        if (workflowId != null) {
+          StepResult recorded =
+              StepsDAO.checkStepResult(conn, ctx.schema(), workflowId, stepId, functionName);
+          if (recorded != null) {
+            logger.debug("Replaying sendBulk, workflowId: {}, stepId: {}", workflowId, stepId);
+            conn.commit();
+            return;
+          }
         }
 
-        var finalMessageId = (messageId != null) ? messageId : UUID.randomUUID().toString();
-        var serializedMsg = SerializationUtil.serializeValue(message, serialization, serializer);
+        // Collect all destination IDs for fork resolution
+        Map<String, Set<String>> forkDescendants = Map.of();
+        if (sendToForks) {
+          List<String> destIds = pairs.stream().map(p -> p.msg().destinationId()).distinct().toList();
+          forkDescendants = findForkDescendantsTxn(conn, ctx.schema(), destIds);
+        }
 
+        // Build insert rows: base dest + sorted descendants
+        record InsertRow(String destId, SerializationUtil.SerializedResult serialized, String topic, String messageUuid) {}
+        List<InsertRow> rows = new ArrayList<>();
+        for (var pair : pairs) {
+          var msg = pair.msg();
+          String baseDest = msg.destinationId();
+          String finalTopic = (msg.topic() != null) ? msg.topic() : Constants.DBOS_NULL_TOPIC;
+
+          List<String> destinations = new ArrayList<>();
+          destinations.add(baseDest);
+          if (sendToForks) {
+            var desc = forkDescendants.getOrDefault(baseDest, Set.of());
+            desc.stream().sorted().forEach(destinations::add);
+          }
+
+          for (String dest : destinations) {
+            String uuid;
+            if (msg.idempotencyKey() != null) {
+              uuid = sendToForks ? msg.idempotencyKey() + "::" + dest : msg.idempotencyKey();
+            } else {
+              uuid = UUID.randomUUID().toString();
+            }
+            rows.add(new InsertRow(dest, pair.serialized(), finalTopic, uuid));
+          }
+        }
+
+        // Batch-insert all rows
         final String sql =
             """
               INSERT INTO "%s".notifications
                 (destination_uuid, topic, message, serialization, message_uuid)
               VALUES (?, ?, ?, ?, ?)
               ON CONFLICT (message_uuid) DO NOTHING
-            """
-                .formatted(ctx.schema());
+            """.formatted(ctx.schema());
 
         try (PreparedStatement stmt = conn.prepareStatement(sql)) {
-          stmt.setString(1, destinationId);
-          stmt.setString(2, finalTopic);
-          stmt.setString(3, serializedMsg.serializedValue());
-          stmt.setString(4, serializedMsg.serialization());
-          stmt.setString(5, finalMessageId);
-          stmt.executeUpdate();
+          for (var row : rows) {
+            stmt.setString(1, row.destId());
+            stmt.setString(2, row.topic());
+            stmt.setString(3, row.serialized().serializedValue());
+            stmt.setString(4, row.serialized().serialization());
+            stmt.setString(5, row.messageUuid());
+            stmt.addBatch();
+          }
+          stmt.executeBatch();
         } catch (SQLException e) {
           if ("23503".equals(e.getSQLState())) {
-            throw new DBOSNonExistentWorkflowException(destinationId);
+            // Find which destination was missing
+            String missingDest = rows.stream().map(InsertRow::destId).findFirst().orElse("unknown");
+            throw new DBOSNonExistentWorkflowException(missingDest);
           }
           throw e;
         }
 
-        var output = new StepResult(workflowId, stepId, functionName, null, null, null, null);
-        StepsDAO.recordStepResult(
-            conn, ctx.schema(), output, startTime, System.currentTimeMillis());
+        if (workflowId != null) {
+          var output = new StepResult(workflowId, stepId, functionName, null, null, null, null);
+          StepsDAO.recordStepResult(conn, ctx.schema(), output, startTime, System.currentTimeMillis());
+        }
 
         conn.commit();
-
       } catch (Exception e) {
         try {
           conn.rollback();
@@ -114,44 +212,6 @@ public class NotificationsDAO {
         }
         throw e;
       }
-    }
-  }
-
-  public static void sendDirect(
-      DbContext ctx,
-      String destinationId,
-      Object message,
-      String topic,
-      String messageId,
-      String serialization)
-      throws SQLException {
-    DBOSSerializer serializer = ctx.serializer();
-    String finalTopic = (topic != null) ? topic : Constants.DBOS_NULL_TOPIC;
-    String finalMessageId = (messageId != null) ? messageId : UUID.randomUUID().toString();
-    var serializedMsg = SerializationUtil.serializeValue(message, serialization, serializer);
-
-    final String sql =
-        """
-          INSERT INTO "%s".notifications
-            (destination_uuid, topic, message, message_uuid, serialization)
-          VALUES (?, ?, ?, ?, ?)
-          ON CONFLICT (message_uuid) DO NOTHING
-        """
-            .formatted(ctx.schema());
-
-    try (var conn = ctx.getConnection();
-        var stmt = conn.prepareStatement(sql)) {
-      stmt.setString(1, destinationId);
-      stmt.setString(2, finalTopic);
-      stmt.setString(3, serializedMsg.serializedValue());
-      stmt.setString(4, finalMessageId);
-      stmt.setString(5, serializedMsg.serialization());
-      stmt.executeUpdate();
-    } catch (SQLException e) {
-      if ("23503".equals(e.getSQLState())) {
-        throw new DBOSNonExistentWorkflowException(destinationId);
-      }
-      throw e;
     }
   }
 

--- a/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/NotificationsDAO.java
@@ -196,9 +196,9 @@ public class NotificationsDAO {
           stmt.executeBatch();
         } catch (SQLException e) {
           if ("23503".equals(e.getSQLState())) {
-            // Find which destination was missing
-            String missingDest = rows.stream().map(InsertRow::destId).findFirst().orElse("unknown");
-            throw new DBOSNonExistentWorkflowException(missingDest);
+            var distinctDests = rows.stream().map(InsertRow::destId).distinct().toList();
+            throw new DBOSNonExistentWorkflowException(
+                distinctDests.size() == 1 ? distinctDests.get(0) : null);
           }
           throw e;
         }

--- a/transact/src/main/java/dev/dbos/transact/exceptions/DBOSNonExistentWorkflowException.java
+++ b/transact/src/main/java/dev/dbos/transact/exceptions/DBOSNonExistentWorkflowException.java
@@ -11,7 +11,10 @@ public class DBOSNonExistentWorkflowException extends RuntimeException {
   private final String workflowId;
 
   public DBOSNonExistentWorkflowException(String workflowId) {
-    super(String.format("Workflow does not exist %s", workflowId));
+    super(
+        workflowId != null
+            ? String.format("Workflow does not exist %s", workflowId)
+            : "One or more destination workflows do not exist");
     this.workflowId = workflowId;
   }
 

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -33,6 +33,7 @@ import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.QueueConflictResolution;
 import dev.dbos.transact.workflow.QueueOptions;
 import dev.dbos.transact.workflow.ScheduleStatus;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.SerializationStrategy;
 import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.StepOptions;
@@ -450,28 +451,54 @@ public class DBOSExecutor implements AutoCloseable {
 
   // DBOS / DBOSClient API methods
 
+  private void sendBulkInternal(
+      List<SendMessage> messages,
+      boolean sendToForks,
+      SerializationStrategy serialization,
+      String functionName) {
+
+    DBOSContext ctx = DBOSContextHolder.get();
+    if (ctx.isInWorkflow() && !ctx.isInStep()) {
+      int stepId = ctx.getAndIncrementFunctionId();
+      systemDatabase.sendBulk(
+          messages,
+          ctx.getWorkflowId(),
+          stepId,
+          functionName,
+          sendToForks,
+          serialization.formatName());
+    } else {
+      systemDatabase.sendBulk(
+          messages, null, -1, functionName, sendToForks, serialization.formatName());
+    }
+  }
+
+  public void sendBulk(
+      List<SendMessage> messages, boolean sendToForks, SerializationStrategy serialization) {
+    sendBulkInternal(messages, sendToForks, serialization, "DBOS.sendBulk");
+  }
+
+  public void send(
+      String destinationId,
+      Object message,
+      String topic,
+      String idempotencyKey,
+      SerializationStrategy serialization,
+      boolean sendToForks) {
+    sendBulkInternal(
+        List.of(new SendMessage(destinationId, message, topic, idempotencyKey)),
+        sendToForks,
+        serialization,
+        "DBOS.send");
+  }
+
   public void send(
       String destinationId,
       Object message,
       String topic,
       String idempotencyKey,
       SerializationStrategy serialization) {
-
-    DBOSContext ctx = DBOSContextHolder.get();
-    if (ctx.isInWorkflow() && !ctx.isInStep()) {
-      int stepId = ctx.getAndIncrementFunctionId();
-      systemDatabase.send(
-          ctx.getWorkflowId(),
-          stepId,
-          destinationId,
-          message,
-          topic,
-          idempotencyKey,
-          serialization.formatName());
-    } else {
-      systemDatabase.sendDirect(
-          destinationId, message, topic, idempotencyKey, serialization.formatName());
-    }
+    send(destinationId, message, topic, idempotencyKey, serialization, false);
   }
 
   public Object recv(String topic, Duration timeout) {

--- a/transact/src/main/java/dev/dbos/transact/workflow/SendMessage.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/SendMessage.java
@@ -13,7 +13,8 @@ public record SendMessage(
     this(destinationId, message, null, null);
   }
 
-  public SendMessage(@NonNull String destinationId, @NonNull Object message, @Nullable String topic) {
+  public SendMessage(
+      @NonNull String destinationId, @NonNull Object message, @Nullable String topic) {
     this(destinationId, message, topic, null);
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/workflow/SendMessage.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/SendMessage.java
@@ -1,0 +1,19 @@
+package dev.dbos.transact.workflow;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public record SendMessage(
+    @NonNull String destinationId,
+    @NonNull Object message,
+    @Nullable String topic,
+    @Nullable String idempotencyKey) {
+
+  public SendMessage(@NonNull String destinationId, @NonNull Object message) {
+    this(destinationId, message, null, null);
+  }
+
+  public SendMessage(@NonNull String destinationId, @NonNull Object message, @Nullable String topic) {
+    this(destinationId, message, topic, null);
+  }
+}

--- a/transact/src/test/java/dev/dbos/transact/client/ClientTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/ClientTest.java
@@ -14,6 +14,7 @@ import dev.dbos.transact.exceptions.DBOSAwaitedWorkflowCancelledException;
 import dev.dbos.transact.exceptions.DBOSNonExistentWorkflowException;
 import dev.dbos.transact.utils.DBUtils;
 import dev.dbos.transact.utils.PgContainer;
+import dev.dbos.transact.workflow.ForkOptions;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.WorkflowState;
@@ -385,5 +386,53 @@ public class ClientTest {
 
     assertEquals("1-msg1", handle1.getResult());
     assertEquals("2-msg2", handle2.getResult());
+  }
+
+  @Test
+  public void testClientSendBulkSendToForks() throws Exception {
+    // Parent is a running workflow; child is a fork (ENQUEUED, not executing)
+    var parent = dbos.startWorkflow(() -> service.sendTest(99));
+    var childId = "fork-child-" + UUID.randomUUID();
+    dbos.forkWorkflow(parent.workflowId(), 0, new ForkOptions(childId));
+
+    var sysdb = DBOSTestAccess.getSystemDatabase(dbos);
+    String key = UUID.randomUUID().toString();
+
+    try (var client = pgContainer.dbosClient()) {
+      client.sendBulk(
+          List.of(new SendMessage(parent.workflowId(), "fan-out", "test-topic", key)),
+          DBOSClient.SendOptions.defaults().withSendToForks(true));
+    }
+
+    // Parent receives the message and completes
+    assertEquals("99-fan-out", parent.getResult());
+
+    // Fork also received the notification (verified via DB since it is not executing)
+    assertEquals(1, sysdb.getAllNotifications(childId).size());
+
+    // Re-send with same key is idempotent — {key}::{dest} UUIDs dedup via ON CONFLICT DO NOTHING
+    try (var client = pgContainer.dbosClient()) {
+      client.sendBulk(
+          List.of(new SendMessage(parent.workflowId(), "fan-out", "test-topic", key)),
+          DBOSClient.SendOptions.defaults().withSendToForks(true));
+    }
+    assertEquals(1, sysdb.getAllNotifications(childId).size());
+  }
+
+  @Test
+  public void testClientSendBulkPortableSerialization() throws Exception {
+    var handle1 = dbos.startWorkflow(() -> service.sendTest(1));
+    var handle2 = dbos.startWorkflow(() -> service.sendTest(2));
+
+    try (var client = pgContainer.dbosClient()) {
+      client.sendBulk(
+          List.of(
+              new SendMessage(handle1.workflowId(), "hello", "test-topic", null),
+              new SendMessage(handle2.workflowId(), "world", "test-topic", null)),
+          DBOSClient.SendOptions.portable());
+    }
+
+    assertEquals("1-hello", handle1.getResult());
+    assertEquals("2-world", handle2.getResult());
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/client/ClientTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/ClientTest.java
@@ -15,10 +15,12 @@ import dev.dbos.transact.exceptions.DBOSNonExistentWorkflowException;
 import dev.dbos.transact.utils.DBUtils;
 import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.Queue;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.WorkflowState;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 
 import com.zaxxer.hikari.HikariDataSource;
@@ -366,5 +368,22 @@ public class ClientTest {
           client.listApplicationVersions().stream().map(v -> v.versionName()).toList();
       assertEquals(dbosVersionNames, clientVersionNames);
     }
+  }
+
+  @Test
+  public void testClientSendBulk() throws Exception {
+    // Start two recv workflows to act as destinations
+    var handle1 = dbos.startWorkflow(() -> service.sendTest(1));
+    var handle2 = dbos.startWorkflow(() -> service.sendTest(2));
+
+    try (var client = pgContainer.dbosClient()) {
+      client.sendBulk(
+          List.of(
+              new SendMessage(handle1.workflowId(), "msg1", "test-topic", null),
+              new SendMessage(handle2.workflowId(), "msg2", "test-topic", null)));
+    }
+
+    assertEquals("1-msg1", handle1.getResult());
+    assertEquals("2-msg2", handle2.getResult());
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -26,6 +26,7 @@ import dev.dbos.transact.workflow.GetWorkflowAggregatesInput;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.QueueOptions;
 import dev.dbos.transact.workflow.ScheduleStatus;
+import dev.dbos.transact.workflow.SendMessage;
 import dev.dbos.transact.workflow.VersionInfo;
 import dev.dbos.transact.workflow.WorkflowDelay;
 import dev.dbos.transact.workflow.WorkflowSchedule;
@@ -1547,8 +1548,20 @@ public class SystemDatabaseTest {
     var wfId = "get-all-notifications-wf-1";
     sysdb.importWorkflow(List.of(buildEmptyWorkflow(wfId)));
 
-    sysdb.sendDirect(wfId, "message1", "topic1", "notif-uuid-1", null);
-    sysdb.sendDirect(wfId, "message2", "topic2", "notif-uuid-2", null);
+    sysdb.sendBulk(
+        List.of(new SendMessage(wfId, "message1", "topic1", "notif-uuid-1")),
+        null,
+        -1,
+        "DBOS.send",
+        false,
+        null);
+    sysdb.sendBulk(
+        List.of(new SendMessage(wfId, "message2", "topic2", "notif-uuid-2")),
+        null,
+        -1,
+        "DBOS.send",
+        false,
+        null);
 
     var notifications = sysdb.getAllNotifications(wfId);
 

--- a/transact/src/test/java/dev/dbos/transact/notifications/SendBulkTest.java
+++ b/transact/src/test/java/dev/dbos/transact/notifications/SendBulkTest.java
@@ -1,0 +1,246 @@
+package dev.dbos.transact.notifications;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import dev.dbos.transact.DBOS;
+import dev.dbos.transact.DBOSTestAccess;
+import dev.dbos.transact.StartWorkflowOptions;
+import dev.dbos.transact.config.DBOSConfig;
+import dev.dbos.transact.database.SystemDatabase;
+import dev.dbos.transact.exceptions.DBOSNonExistentWorkflowException;
+import dev.dbos.transact.utils.PgContainer;
+import dev.dbos.transact.workflow.ForkOptions;
+import dev.dbos.transact.workflow.SendMessage;
+import dev.dbos.transact.workflow.Workflow;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+interface BulkService {
+  String block(String topic);
+}
+
+class BulkServiceImpl implements BulkService {
+  private final DBOS dbos;
+
+  BulkServiceImpl(DBOS dbos) {
+    this.dbos = dbos;
+  }
+
+  @Workflow
+  @Override
+  public String block(String topic) {
+    return dbos.<String>recv(topic, Duration.ofSeconds(30)).orElse(null);
+  }
+}
+
+class SendBulkTest {
+
+  @AutoClose final PgContainer pgContainer = new PgContainer();
+
+  private DBOSConfig dbosConfig;
+  @AutoClose private DBOS dbos;
+  private BulkService service;
+
+  @BeforeEach
+  void setup() {
+    dbosConfig = pgContainer.dbosConfig();
+    dbos = new DBOS(dbosConfig);
+    service = dbos.registerProxy(BulkService.class, new BulkServiceImpl(dbos));
+    dbos.launch();
+  }
+
+  private SystemDatabase db() {
+    return DBOSTestAccess.getSystemDatabase(dbos);
+  }
+
+  /** Starts a blocking workflow that provides a valid workflow_status row. */
+  private String startBlockingWorkflow(String id) throws Exception {
+    dbos.startWorkflow(() -> service.block(id), new StartWorkflowOptions(id));
+    return id;
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkEmpty
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkEmpty() {
+    // Outside workflow: should be a complete no-op
+    assertDoesNotThrow(() -> db().sendBulk(List.of(), null, -1, "DBOS.sendBulk", false, null));
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkBasic
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkBasic() throws Exception {
+    String dest1 = startBlockingWorkflow("dest1-" + UUID.randomUUID());
+    String dest2 = startBlockingWorkflow("dest2-" + UUID.randomUUID());
+
+    // Two messages to dest1, one message to dest2, all in one call
+    db().sendBulk(
+        List.of(
+            new SendMessage(dest1, "hello-1"),
+            new SendMessage(dest1, "hello-2"),
+            new SendMessage(dest2, "world")),
+        null,
+        -1,
+        "DBOS.sendBulk",
+        false,
+        null);
+
+    var notes1 = db().getAllNotifications(dest1);
+    assertEquals(2, notes1.size());
+
+    var notes2 = db().getAllNotifications(dest2);
+    assertEquals(1, notes2.size());
+    assertEquals("world", notes2.get(0).message());
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkNonExistentDest — entire tx rolls back
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkNonExistentDest() throws Exception {
+    String validDest = startBlockingWorkflow("valid-" + UUID.randomUUID());
+
+    assertThrows(
+        DBOSNonExistentWorkflowException.class,
+        () ->
+            db().sendBulk(
+                List.of(
+                    new SendMessage(validDest, "first"),
+                    new SendMessage("nonexistent-" + UUID.randomUUID(), "second")),
+                null,
+                -1,
+                "DBOS.sendBulk",
+                false,
+                null));
+
+    // Atomicity: valid dest must have received nothing
+    assertEquals(0, db().getAllNotifications(validDest).size());
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkDuplicateKeyWithinBatch — rejected before transaction opens
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkDuplicateKeyWithinBatch() throws Exception {
+    String dest = startBlockingWorkflow("dupkey-dest-" + UUID.randomUUID());
+    String key = UUID.randomUUID().toString();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            db().sendBulk(
+                List.of(
+                    new SendMessage(dest, "msg1", null, key),
+                    new SendMessage(dest, "msg2", null, key)),
+                null,
+                -1,
+                "DBOS.sendBulk",
+                false,
+                null));
+
+    // Nothing was delivered
+    assertEquals(0, db().getAllNotifications(dest).size());
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkIdempotencyKey — duplicate across calls is deduped
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkIdempotencyKey() throws Exception {
+    String dest = startBlockingWorkflow("idem-dest-" + UUID.randomUUID());
+    String key = UUID.randomUUID().toString();
+
+    var messages = List.of(new SendMessage(dest, "hello", null, key));
+    db().sendBulk(messages, null, -1, "DBOS.sendBulk", false, null);
+    db().sendBulk(messages, null, -1, "DBOS.sendBulk", false, null);
+
+    // Only one notification despite two calls
+    assertEquals(1, db().getAllNotifications(dest).size());
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkFromWorkflow — step is recorded; replay skips re-delivery
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkFromWorkflow() throws Exception {
+    // senderWf provides a real workflow_status row to act as the sender context
+    String senderWf = startBlockingWorkflow("sender-wf-" + UUID.randomUUID());
+    String dest = startBlockingWorkflow("wf-dest-" + UUID.randomUUID());
+
+    var messages = List.of(new SendMessage(dest, "from-workflow"));
+    // Use stepId 100 to stay clear of the recv workflow's own step IDs
+    db().sendBulk(messages, senderWf, 100, "DBOS.sendBulk", false, null);
+
+    assertEquals(1, db().getAllNotifications(dest).size());
+
+    // The sendBulk step should be recorded in the sender workflow's history
+    var steps = dbos.listWorkflowSteps(senderWf);
+    assertTrue(steps.stream().anyMatch(s -> "DBOS.sendBulk".equals(s.functionName())));
+
+    // Second call with same workflowId/stepId is a replay — no new delivery
+    db().sendBulk(messages, senderWf, 100, "DBOS.sendBulk", false, null);
+    assertEquals(1, db().getAllNotifications(dest).size());
+  }
+
+  // -------------------------------------------------------------------------
+  // testSendBulkSendToForks — fan-out to recursive fork tree
+  // -------------------------------------------------------------------------
+
+  @Test
+  void testSendBulkSendToForks() throws Exception {
+    // Build the tree: parent -> child -> grandchild
+    String parentId = "parent-" + UUID.randomUUID();
+    String childId = "child-" + UUID.randomUUID();
+    String grandchildId = "grandchild-" + UUID.randomUUID();
+    String unrelatedId = "unrelated-" + UUID.randomUUID();
+
+    startBlockingWorkflow(parentId);
+    startBlockingWorkflow(unrelatedId);
+    dbos.forkWorkflow(parentId, 0, new ForkOptions(childId));
+    dbos.forkWorkflow(childId, 0, new ForkOptions(grandchildId));
+
+    String key = UUID.randomUUID().toString();
+    db().sendBulk(
+        List.of(new SendMessage(parentId, "fan-out", null, key)),
+        null,
+        -1,
+        "DBOS.sendBulk",
+        true,
+        null);
+
+    // All three should have received the message
+    assertEquals(1, db().getAllNotifications(parentId).size());
+    assertEquals(1, db().getAllNotifications(childId).size());
+    assertEquals(1, db().getAllNotifications(grandchildId).size());
+
+    // Unrelated workflow receives nothing
+    assertEquals(0, db().getAllNotifications(unrelatedId).size());
+
+    // Message UUIDs follow the {key}::{dest} pattern — sending again is idempotent
+    db().sendBulk(
+        List.of(new SendMessage(parentId, "fan-out", null, key)),
+        null,
+        -1,
+        "DBOS.sendBulk",
+        true,
+        null);
+    assertEquals(1, db().getAllNotifications(parentId).size());
+    assertEquals(1, db().getAllNotifications(childId).size());
+    assertEquals(1, db().getAllNotifications(grandchildId).size());
+  }
+}

--- a/transact/src/test/java/dev/dbos/transact/notifications/SendBulkTest.java
+++ b/transact/src/test/java/dev/dbos/transact/notifications/SendBulkTest.java
@@ -85,7 +85,8 @@ class SendBulkTest {
 
     // Inside workflow: also a no-op, no step recorded
     String wfId = "empty-wf-" + UUID.randomUUID();
-    service.sendBulkWorkflow(List.of());
+    dbos.startWorkflow(() -> service.sendBulkWorkflow(List.of()), new StartWorkflowOptions(wfId))
+        .getResult();
     assertEquals(0, dbos.listWorkflowSteps(wfId).size());
   }
 

--- a/transact/src/test/java/dev/dbos/transact/notifications/SendBulkTest.java
+++ b/transact/src/test/java/dev/dbos/transact/notifications/SendBulkTest.java
@@ -11,6 +11,7 @@ import dev.dbos.transact.exceptions.DBOSNonExistentWorkflowException;
 import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.ForkOptions;
 import dev.dbos.transact.workflow.SendMessage;
+import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.Workflow;
 
 import java.time.Duration;
@@ -23,6 +24,8 @@ import org.junit.jupiter.api.Test;
 
 interface BulkService {
   String block(String topic);
+
+  void sendBulkWorkflow(List<SendMessage> messages);
 }
 
 class BulkServiceImpl implements BulkService {
@@ -36,6 +39,12 @@ class BulkServiceImpl implements BulkService {
   @Override
   public String block(String topic) {
     return dbos.<String>recv(topic, Duration.ofSeconds(30)).orElse(null);
+  }
+
+  @Workflow
+  @Override
+  public void sendBulkWorkflow(List<SendMessage> messages) {
+    dbos.sendBulk(messages);
   }
 }
 
@@ -59,8 +68,8 @@ class SendBulkTest {
     return DBOSTestAccess.getSystemDatabase(dbos);
   }
 
-  /** Starts a blocking workflow that provides a valid workflow_status row. */
-  private String startBlockingWorkflow(String id) throws Exception {
+  /** Starts a blocking recv workflow, providing a valid workflow_status row as a destination. */
+  private String startDest(String id) throws Exception {
     dbos.startWorkflow(() -> service.block(id), new StartWorkflowOptions(id));
     return id;
   }
@@ -71,174 +80,138 @@ class SendBulkTest {
 
   @Test
   void testSendBulkEmpty() {
-    // Outside workflow: should be a complete no-op
-    assertDoesNotThrow(() -> db().sendBulk(List.of(), null, -1, "DBOS.sendBulk", false, null));
+    // Outside workflow: no-op
+    assertDoesNotThrow(() -> dbos.sendBulk(List.of()));
+
+    // Inside workflow: also a no-op, no step recorded
+    String wfId = "empty-wf-" + UUID.randomUUID();
+    service.sendBulkWorkflow(List.of());
+    assertEquals(0, dbos.listWorkflowSteps(wfId).size());
   }
 
   // -------------------------------------------------------------------------
-  // testSendBulkBasic
+  // testSendBulk
   // -------------------------------------------------------------------------
 
   @Test
-  void testSendBulkBasic() throws Exception {
-    String dest1 = startBlockingWorkflow("dest1-" + UUID.randomUUID());
-    String dest2 = startBlockingWorkflow("dest2-" + UUID.randomUUID());
+  void testSendBulk() throws Exception {
+    String dest1 = startDest("dest1-" + UUID.randomUUID());
+    String dest2 = startDest("dest2-" + UUID.randomUUID());
 
-    // Two messages to dest1, one message to dest2, all in one call
-    db().sendBulk(
+    // Multi-message to one dest + one message to another, all atomic
+    dbos.sendBulk(
         List.of(
             new SendMessage(dest1, "hello-1"),
             new SendMessage(dest1, "hello-2"),
-            new SendMessage(dest2, "world")),
-        null,
-        -1,
-        "DBOS.sendBulk",
-        false,
-        null);
+            new SendMessage(dest2, "world")));
 
-    var notes1 = db().getAllNotifications(dest1);
-    assertEquals(2, notes1.size());
+    assertEquals(2, db().getAllNotifications(dest1).size());
+    assertEquals(1, db().getAllNotifications(dest2).size());
+    assertEquals("world", db().getAllNotifications(dest2).get(0).message());
 
-    var notes2 = db().getAllNotifications(dest2);
-    assertEquals(1, notes2.size());
-    assertEquals("world", notes2.get(0).message());
-  }
-
-  // -------------------------------------------------------------------------
-  // testSendBulkNonExistentDest — entire tx rolls back
-  // -------------------------------------------------------------------------
-
-  @Test
-  void testSendBulkNonExistentDest() throws Exception {
-    String validDest = startBlockingWorkflow("valid-" + UUID.randomUUID());
-
+    // Non-existent destination rolls back the entire batch
+    String validDest = startDest("valid-" + UUID.randomUUID());
     assertThrows(
         DBOSNonExistentWorkflowException.class,
         () ->
-            db().sendBulk(
+            dbos.sendBulk(
                 List.of(
                     new SendMessage(validDest, "first"),
-                    new SendMessage("nonexistent-" + UUID.randomUUID(), "second")),
-                null,
-                -1,
-                "DBOS.sendBulk",
-                false,
-                null));
-
-    // Atomicity: valid dest must have received nothing
+                    new SendMessage("nonexistent-" + UUID.randomUUID(), "second"))));
     assertEquals(0, db().getAllNotifications(validDest).size());
   }
 
   // -------------------------------------------------------------------------
-  // testSendBulkDuplicateKeyWithinBatch — rejected before transaction opens
+  // testSendBulkFromWorkflow
   // -------------------------------------------------------------------------
 
   @Test
-  void testSendBulkDuplicateKeyWithinBatch() throws Exception {
-    String dest = startBlockingWorkflow("dupkey-dest-" + UUID.randomUUID());
-    String key = UUID.randomUUID().toString();
+  void testSendBulkFromWorkflow() throws Exception {
+    String dest = startDest("wf-dest-" + UUID.randomUUID());
 
-    assertThrows(
-        IllegalArgumentException.class,
-        () ->
-            db().sendBulk(
-                List.of(
-                    new SendMessage(dest, "msg1", null, key),
-                    new SendMessage(dest, "msg2", null, key)),
-                null,
-                -1,
-                "DBOS.sendBulk",
-                false,
-                null));
+    // Run the sendBulk workflow and wait for it to complete
+    String senderWfId = "sender-wf-" + UUID.randomUUID();
+    var handle =
+        dbos.startWorkflow(
+            () -> service.sendBulkWorkflow(List.of(new SendMessage(dest, "from-workflow"))),
+            new StartWorkflowOptions(senderWfId));
+    handle.getResult();
 
-    // Nothing was delivered
-    assertEquals(0, db().getAllNotifications(dest).size());
+    assertEquals(1, db().getAllNotifications(dest).size());
+
+    // The entire bulk send is recorded as exactly one step
+    List<StepInfo> steps = dbos.listWorkflowSteps(senderWfId);
+    assertEquals(1, steps.size());
+    assertEquals("DBOS.sendBulk", steps.get(0).functionName());
   }
 
   // -------------------------------------------------------------------------
-  // testSendBulkIdempotencyKey — duplicate across calls is deduped
+  // testSendBulkIdempotencyKey
   // -------------------------------------------------------------------------
 
   @Test
   void testSendBulkIdempotencyKey() throws Exception {
-    String dest = startBlockingWorkflow("idem-dest-" + UUID.randomUUID());
+    String dest = startDest("idem-dest-" + UUID.randomUUID());
     String key = UUID.randomUUID().toString();
 
     var messages = List.of(new SendMessage(dest, "hello", null, key));
-    db().sendBulk(messages, null, -1, "DBOS.sendBulk", false, null);
-    db().sendBulk(messages, null, -1, "DBOS.sendBulk", false, null);
+    dbos.sendBulk(messages);
+    dbos.sendBulk(messages);
 
     // Only one notification despite two calls
     assertEquals(1, db().getAllNotifications(dest).size());
   }
 
   // -------------------------------------------------------------------------
-  // testSendBulkFromWorkflow — step is recorded; replay skips re-delivery
+  // testSendBulkDuplicateKeyWithinBatch
   // -------------------------------------------------------------------------
 
   @Test
-  void testSendBulkFromWorkflow() throws Exception {
-    // senderWf provides a real workflow_status row to act as the sender context
-    String senderWf = startBlockingWorkflow("sender-wf-" + UUID.randomUUID());
-    String dest = startBlockingWorkflow("wf-dest-" + UUID.randomUUID());
+  void testSendBulkDuplicateKeyWithinBatch() throws Exception {
+    String dest = startDest("dupkey-dest-" + UUID.randomUUID());
+    String key = UUID.randomUUID().toString();
 
-    var messages = List.of(new SendMessage(dest, "from-workflow"));
-    // Use stepId 100 to stay clear of the recv workflow's own step IDs
-    db().sendBulk(messages, senderWf, 100, "DBOS.sendBulk", false, null);
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            dbos.sendBulk(
+                List.of(
+                    new SendMessage(dest, "msg1", null, key),
+                    new SendMessage(dest, "msg2", null, key))));
 
-    assertEquals(1, db().getAllNotifications(dest).size());
-
-    // The sendBulk step should be recorded in the sender workflow's history
-    var steps = dbos.listWorkflowSteps(senderWf);
-    assertTrue(steps.stream().anyMatch(s -> "DBOS.sendBulk".equals(s.functionName())));
-
-    // Second call with same workflowId/stepId is a replay — no new delivery
-    db().sendBulk(messages, senderWf, 100, "DBOS.sendBulk", false, null);
-    assertEquals(1, db().getAllNotifications(dest).size());
+    // Nothing was delivered
+    assertEquals(0, db().getAllNotifications(dest).size());
   }
 
   // -------------------------------------------------------------------------
-  // testSendBulkSendToForks — fan-out to recursive fork tree
+  // testSendBulkSendToForks
   // -------------------------------------------------------------------------
 
   @Test
   void testSendBulkSendToForks() throws Exception {
-    // Build the tree: parent -> child -> grandchild
     String parentId = "parent-" + UUID.randomUUID();
     String childId = "child-" + UUID.randomUUID();
     String grandchildId = "grandchild-" + UUID.randomUUID();
     String unrelatedId = "unrelated-" + UUID.randomUUID();
 
-    startBlockingWorkflow(parentId);
-    startBlockingWorkflow(unrelatedId);
+    startDest(parentId);
+    startDest(unrelatedId);
     dbos.forkWorkflow(parentId, 0, new ForkOptions(childId));
     dbos.forkWorkflow(childId, 0, new ForkOptions(grandchildId));
 
     String key = UUID.randomUUID().toString();
-    db().sendBulk(
-        List.of(new SendMessage(parentId, "fan-out", null, key)),
-        null,
-        -1,
-        "DBOS.sendBulk",
-        true,
-        null);
+    dbos.sendBulk(List.of(new SendMessage(parentId, "fan-out", null, key)), true);
 
-    // All three should have received the message
+    // Fan-out reaches all descendants
     assertEquals(1, db().getAllNotifications(parentId).size());
     assertEquals(1, db().getAllNotifications(childId).size());
     assertEquals(1, db().getAllNotifications(grandchildId).size());
 
-    // Unrelated workflow receives nothing
+    // Unrelated workflow untouched
     assertEquals(0, db().getAllNotifications(unrelatedId).size());
 
-    // Message UUIDs follow the {key}::{dest} pattern — sending again is idempotent
-    db().sendBulk(
-        List.of(new SendMessage(parentId, "fan-out", null, key)),
-        null,
-        -1,
-        "DBOS.sendBulk",
-        true,
-        null);
+    // Re-send with same key is idempotent (ON CONFLICT DO NOTHING via {key}::{dest} UUIDs)
+    dbos.sendBulk(List.of(new SendMessage(parentId, "fan-out", null, key)), true);
     assertEquals(1, db().getAllNotifications(parentId).size());
     assertEquals(1, db().getAllNotifications(childId).size());
     assertEquals(1, db().getAllNotifications(grandchildId).size());


### PR DESCRIPTION
Adds `sendBulk()` to the public API (DBOS and DBOSClient), allowing a list of messages to be sent to one or more workflow destinations atomically in a single database transaction. Also adds `sendToForks` support to both `send()` and `sendBulk()`, which fans out each message to every workflow recursively forked from the destination.

fixes #402 
