### PR TITLE
ExternalState.updateTime Instant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+### Scala Metals LSP files
+.metals/

--- a/transact/src/main/java/dev/dbos/transact/database/ExternalState.java
+++ b/transact/src/main/java/dev/dbos/transact/database/ExternalState.java
@@ -1,7 +1,7 @@
 package dev.dbos.transact.database;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.util.Objects;
 
 /**
@@ -19,8 +19,8 @@ import java.util.Objects;
  * @param key The key under which the external state is stored, allowing multiple values per service
  *     and workflow combination.
  * @param value The current value associated with the key.
- * @param updateTime The timestamp of the last update, represented as a decimal (e.g., UNIX epoch
- *     seconds), or {@code null} if unused.
+ * @param updateTime The timestamp of the last update, stored as epoch milliseconds in the database,
+ *     or {@code null} if unused.
  * @param updateSeq A monotonic sequence number for updates, used to detect the latest version, or
  *     {@code null} if not applicable.
  */
@@ -29,7 +29,7 @@ public record ExternalState(
     String workflowName,
     String key,
     String value,
-    BigDecimal updateTime,
+    Instant updateTime,
     BigInteger updateSeq) {
 
   public ExternalState {
@@ -61,9 +61,9 @@ public record ExternalState(
   /**
    * Create an {@code ExternalState} like this one, but with a new update time
    *
-   * @param updateTime update time to use, as a decimal number of seconds since the Unix epoch
+   * @param updateTime update time to use
    */
-  public ExternalState withUpdateTime(BigDecimal updateTime) {
+  public ExternalState withUpdateTime(Instant updateTime) {
     return new ExternalState(service, workflowName, key, value, updateTime, updateSeq);
   }
 

--- a/transact/src/main/java/dev/dbos/transact/database/dao/ExternalStateDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/ExternalStateDAO.java
@@ -93,14 +93,17 @@ public class ExternalStateDAO {
   }
 
   private static BigDecimal instantToBigDecimal(Instant instant) {
-    return BigDecimal.valueOf(instant.getEpochSecond())
-        .add(BigDecimal.valueOf(instant.getNano(), 9));
+    long epochMs = instant.toEpochMilli();
+    int subMsNanos = instant.getNano() % 1_000_000;
+    return BigDecimal.valueOf(epochMs).add(BigDecimal.valueOf(subMsNanos, 9));
   }
 
   private static Instant bigDecimalToInstant(BigDecimal value) {
     BigDecimal floor = value.setScale(0, RoundingMode.FLOOR);
-    long seconds = floor.longValue();
-    int nanos = value.subtract(floor).movePointRight(9).intValue();
-    return Instant.ofEpochSecond(seconds, nanos);
+    long epochMs = floor.longValue();
+    int subMsNanos = value.subtract(floor).movePointRight(9).intValue();
+    long epochSec = epochMs / 1000;
+    int nanos = (int) (epochMs % 1000) * 1_000_000 + subMsNanos;
+    return Instant.ofEpochSecond(epochSec, nanos);
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/database/dao/ExternalStateDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/ExternalStateDAO.java
@@ -5,7 +5,9 @@ import dev.dbos.transact.database.ExternalState;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -32,7 +34,8 @@ public class ExternalStateDAO {
           var value = rs.getString("value");
           BigDecimal seqDecimal = rs.getBigDecimal("update_seq");
           BigInteger seq = seqDecimal != null ? seqDecimal.toBigInteger() : null;
-          BigDecimal time = rs.getBigDecimal("update_time");
+          BigDecimal timeDecimal = rs.getBigDecimal("update_time");
+          Instant time = timeDecimal != null ? bigDecimalToInstant(timeDecimal) : null;
           return Optional.of(new ExternalState(service, workflowName, key, value, time, seq));
         } else {
           return Optional.empty();
@@ -67,7 +70,8 @@ public class ExternalStateDAO {
           2, Objects.requireNonNull(state.workflowName(), "workflowName must not be null"));
       stmt.setString(3, Objects.requireNonNull(state.key(), "key must not be null"));
       stmt.setString(4, state.value());
-      stmt.setObject(5, state.updateTime());
+      Instant updateTime = state.updateTime();
+      stmt.setBigDecimal(5, updateTime != null ? instantToBigDecimal(updateTime) : null);
       stmt.setObject(6, state.updateSeq());
 
       try (var rs = stmt.executeQuery()) {
@@ -75,7 +79,8 @@ public class ExternalStateDAO {
           var value = rs.getString("value");
           BigDecimal seqDecimal = rs.getBigDecimal("update_seq");
           BigInteger seq = seqDecimal != null ? seqDecimal.toBigInteger() : null;
-          BigDecimal time = rs.getBigDecimal("update_time");
+          BigDecimal timeDecimal = rs.getBigDecimal("update_time");
+          Instant time = timeDecimal != null ? bigDecimalToInstant(timeDecimal) : null;
           return new ExternalState(
               state.service(), state.workflowName(), state.key(), value, time, seq);
         } else {
@@ -85,5 +90,17 @@ public class ExternalStateDAO {
         }
       }
     }
+  }
+
+  private static BigDecimal instantToBigDecimal(Instant instant) {
+    return BigDecimal.valueOf(instant.getEpochSecond())
+        .add(BigDecimal.valueOf(instant.getNano(), 9));
+  }
+
+  private static Instant bigDecimalToInstant(BigDecimal value) {
+    BigDecimal floor = value.setScale(0, RoundingMode.FLOOR);
+    long seconds = floor.longValue();
+    int nanos = value.subtract(floor).movePointRight(9).intValue();
+    return Instant.ofEpochSecond(seconds, nanos);
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/database/ExternalStateTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/ExternalStateTest.java
@@ -8,8 +8,9 @@ import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.migrations.MigrationManager;
 import dev.dbos.transact.utils.PgContainer;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Instant;
 
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,9 +35,8 @@ public class ExternalStateTest {
     var service = "test-service-name";
     var workflow = "test-workflow-name";
     var key = "externalStateTime-key";
-    var nowMS = System.currentTimeMillis();
-    var value = "%d".formatted(nowMS);
-    var now = BigDecimal.valueOf(nowMS).setScale(15);
+    var now = Instant.now();
+    var value = "%d".formatted(now.toEpochMilli());
 
     // insert initial value
     var insState =
@@ -60,13 +60,12 @@ public class ExternalStateTest {
     assertNull(getState.get().updateSeq());
 
     // upsert older timestamp doesn't change the value
-    var newNowMS = nowMS - 10;
-    var newValue = "%d".formatted(newNowMS);
-    var newNow = BigDecimal.valueOf(newNowMS).setScale(15);
+    var pastNow = now.minus(Duration.ofMillis(10));
+    var pastValue = "%d".formatted(pastNow.toEpochMilli());
 
     var upState =
         systemDatabase.upsertExternalState(
-            new ExternalState(service, workflow, key).withValue(newValue).withUpdateTime(newNow));
+            new ExternalState(service, workflow, key).withValue(pastValue).withUpdateTime(pastNow));
     assertEquals(service, upState.service());
     assertEquals(workflow, upState.workflowName());
     assertEquals(key, upState.key());
@@ -75,18 +74,19 @@ public class ExternalStateTest {
     assertNull(upState.updateSeq());
 
     // upsert later timestamp does change the value
-    newNowMS = nowMS + 10;
-    newValue = "%d".formatted(newNowMS);
-    newNow = BigDecimal.valueOf(newNowMS).setScale(15);
+    var futureNow = now.plus(Duration.ofMillis(10));
+    var futureValue = "%d".formatted(futureNow.toEpochMilli());
 
     upState =
         systemDatabase.upsertExternalState(
-            new ExternalState(service, workflow, key).withValue(newValue).withUpdateTime(newNow));
+            new ExternalState(service, workflow, key)
+                .withValue(futureValue)
+                .withUpdateTime(futureNow));
     assertEquals(service, upState.service());
     assertEquals(workflow, upState.workflowName());
     assertEquals(key, upState.key());
-    assertEquals(newValue, upState.value());
-    assertEquals(newNow, upState.updateTime());
+    assertEquals(futureValue, upState.value());
+    assertEquals(futureNow, upState.updateTime());
     assertNull(upState.updateSeq());
   }
 
@@ -95,9 +95,8 @@ public class ExternalStateTest {
     var service = "test-service-name";
     var workflow = "test-workflow-name";
     var key = "externalStateSeq-key";
-    var nowMS = System.currentTimeMillis();
-    var value = "%d".formatted(nowMS);
-    var seq = BigInteger.valueOf(nowMS);
+    BigInteger seq = BigInteger.valueOf(10);
+    var value = "%d".formatted(seq.longValue());
 
     // insert initial value
     var state =
@@ -121,13 +120,11 @@ public class ExternalStateTest {
     assertNull(getState.get().updateTime());
 
     // upsert older timestamp doesn't change the value
-    var newNowMS = nowMS - 10;
-    var newValue = "%d".formatted(newNowMS);
-    var newSeq = BigInteger.valueOf(newNowMS);
-
+    var oldSeq = seq.subtract(BigInteger.valueOf(1));
+    var oldValue = "%d".formatted(oldSeq.longValue());
     state =
         systemDatabase.upsertExternalState(
-            new ExternalState(service, workflow, key).withValue(newValue).withUpdateSeq(newSeq));
+            new ExternalState(service, workflow, key).withValue(oldValue).withUpdateSeq(oldSeq));
     assertEquals(service, state.service());
     assertEquals(workflow, state.workflowName());
     assertEquals(key, state.key());
@@ -136,10 +133,8 @@ public class ExternalStateTest {
     assertNull(state.updateTime());
 
     // upsert later timestamp does change the value
-    newNowMS = nowMS + 10;
-    newValue = "%d".formatted(newNowMS);
-    newSeq = BigInteger.valueOf(newNowMS);
-
+    var newSeq = seq.add(BigInteger.valueOf(1));
+    var newValue = "%d".formatted(newSeq.longValue());
     state =
         systemDatabase.upsertExternalState(
             new ExternalState(service, workflow, key).withValue(newValue).withUpdateSeq(newSeq));

--- a/transact/src/test/java/dev/dbos/transact/database/ExternalStateTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/ExternalStateTest.java
@@ -8,7 +8,9 @@ import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.migrations.MigrationManager;
 import dev.dbos.transact.utils.PgContainer;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.Instant;
 
@@ -144,5 +146,65 @@ public class ExternalStateTest {
     assertEquals(newValue, state.value());
     assertEquals(newSeq, state.updateSeq());
     assertNull(state.updateTime());
+  }
+
+  @Test
+  public void backwardCompatibleWithEpochMs() throws SQLException {
+    var service = "backward-service";
+    var workflow = "backward-workflow";
+    var key = "backward-key";
+
+    // Insert old-format row: epoch ms as whole number (no fractional part)
+    try (var conn = pgContainer.dataSource().getConnection();
+        var stmt =
+            conn.prepareStatement(
+                "INSERT INTO \"dbos\".event_dispatch_kv (service_name, workflow_fn_name, key, value, update_time) VALUES (?, ?, ?, ?, ?)")) {
+      stmt.setString(1, service);
+      stmt.setString(2, workflow);
+      stmt.setString(3, key);
+      stmt.setString(4, "old-value");
+      stmt.setBigDecimal(5, BigDecimal.valueOf(1000));
+      stmt.executeUpdate();
+    }
+
+    // Upsert with a newer Instant (epoch ms = 2000, larger integer part)
+    var newInstant = Instant.ofEpochMilli(2000);
+    var result =
+        systemDatabase.upsertExternalState(
+            new ExternalState(service, workflow, key)
+                .withValue("new-value")
+                .withUpdateTime(newInstant));
+    assertEquals("new-value", result.value());
+    assertEquals(newInstant, result.updateTime());
+
+    // Verify via get
+    var getResult = systemDatabase.getExternalState(service, workflow, key);
+    assertTrue(getResult.isPresent());
+    assertEquals("new-value", getResult.get().value());
+    assertEquals(newInstant, getResult.get().updateTime());
+
+    // Insert another old-format row
+    key = "backward-key-older";
+    try (var conn = pgContainer.dataSource().getConnection();
+        var stmt =
+            conn.prepareStatement(
+                "INSERT INTO \"dbos\".event_dispatch_kv (service_name, workflow_fn_name, key, value, update_time) VALUES (?, ?, ?, ?, ?)")) {
+      stmt.setString(1, service);
+      stmt.setString(2, workflow);
+      stmt.setString(3, key);
+      stmt.setString(4, "old-value");
+      stmt.setBigDecimal(5, BigDecimal.valueOf(2000));
+      stmt.executeUpdate();
+    }
+
+    // Upsert with an older Instant (epoch ms = 1500) — value should NOT change
+    var olderInstant = Instant.ofEpochMilli(1500);
+    var noChange =
+        systemDatabase.upsertExternalState(
+            new ExternalState(service, workflow, key)
+                .withValue("should-not-appear")
+                .withUpdateTime(olderInstant));
+    assertEquals("old-value", noChange.value());
+    assertEquals(Instant.ofEpochMilli(2000), noChange.updateTime());
   }
 }


### PR DESCRIPTION
** BREAKING CHANGE ** (limited scope to event receivers)

Changes ExternalState.updateTime from a BigDecimal to an Instant. Stores the value in the `NUMERIC(38,15)` update_time column as fractional milliseconds. This provides backwards compatibility (previously we expected users to store whole epoch ms in update_time) while also providing full Instant nanosecond precision.

