### PR TITLE
Optimize Queues

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/DBOSClient.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOSClient.java
@@ -621,8 +621,6 @@ public class DBOSClient implements AutoCloseable {
             options.queuePartitionKey,
             options.delay,
             options.appVersion,
-            false,
-            false,
             serializationFormat),
         null,
         null,

--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -447,11 +447,16 @@ public class SystemDatabase implements AutoCloseable {
     return dbRetry(() -> WorkflowDAO.<T>awaitWorkflowResult(ctx, dbPollingInterval, workflowId));
   }
 
-  public List<String> getAndStartQueuedWorkflows(
-      Queue queue, String executorId, String appVersion, String partitionKey) {
+  public List<String> startQueuedWorkflows(
+      Queue queue,
+      String executorId,
+      String appVersion,
+      String partitionKey,
+      long localRunningCount) {
     return dbRetry(
         () ->
-            QueuesDAO.getAndStartQueuedWorkflows(ctx, queue, executorId, appVersion, partitionKey));
+            QueuesDAO.startQueuedWorkflows(
+                ctx, queue, executorId, appVersion, partitionKey, localRunningCount));
   }
 
   public void recordChildWorkflow(

--- a/transact/src/main/java/dev/dbos/transact/database/dao/QueuesDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/QueuesDAO.java
@@ -10,13 +10,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -28,8 +25,13 @@ public class QueuesDAO {
 
   private static final Logger logger = LoggerFactory.getLogger(QueuesDAO.class);
 
-  public static List<String> getAndStartQueuedWorkflows(
-      DbContext ctx, Queue queue, String executorId, String appVersion, String partitionKey)
+  public static List<String> startQueuedWorkflows(
+      DbContext ctx,
+      Queue queue,
+      String executorId,
+      String appVersion,
+      String partitionKey,
+      long localRunningCount)
       throws SQLException {
 
     if (partitionKey != null && partitionKey.isEmpty()) {
@@ -38,22 +40,24 @@ public class QueuesDAO {
 
     try (Connection connection = ctx.getConnection()) {
       connection.setAutoCommit(false);
-
-      try (Statement stmt = connection.createStatement()) {
-        stmt.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+      // Use REPEATABLE READ only when global flow control (concurrency or rate limit) is active.
+      // Local worker concurrency is tracked in-memory and does not need a consistent DB snapshot.
+      if (queue.concurrency() != null || queue.rateLimit() != null) {
+        connection.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
       }
 
       int numRecentQueries = 0;
 
-      var rateLimit = queue.rateLimit();
-      if (rateLimit != null) {
-        var cutoffTime = Instant.now().minus(rateLimit.period());
+      // If there is a rate limit, compute how many functions have started in its period.
+      if (queue.rateLimit() != null) {
+        var rateLimit = queue.rateLimit();
 
         var limiterQuery =
             """
               SELECT COUNT(*)
               FROM "%s".workflow_status
               WHERE queue_name = ?
+              AND rate_limited = true
               AND status NOT IN (?, ?)
               AND started_at_epoch_ms > ?
             """
@@ -66,7 +70,7 @@ public class QueuesDAO {
           ps.setString(1, queue.name());
           ps.setString(2, WorkflowState.ENQUEUED.name());
           ps.setString(3, WorkflowState.DELAYED.name());
-          ps.setLong(4, cutoffTime.toEpochMilli());
+          ps.setLong(4, Instant.now().minus(rateLimit.period()).toEpochMilli());
           if (partitionKey != null) {
             ps.setString(5, partitionKey);
           }
@@ -78,28 +82,33 @@ public class QueuesDAO {
           }
         }
 
-        if (numRecentQueries >= queue.rateLimit().limit()) {
-          return new ArrayList<>();
+        if (numRecentQueries >= rateLimit.limit()) {
+          return List.of();
         }
       }
 
-      int maxTasks = 100;
+      long maxTasks = Integer.MAX_VALUE;
 
-      if (queue.workerConcurrency() != null || queue.concurrency() != null) {
-        String pendingQuery =
+      // Worker concurrency uses the caller-supplied in-memory count — no DB round trip needed.
+      if (queue.workerConcurrency() != null) {
+        maxTasks = Math.max(0, queue.workerConcurrency() - localRunningCount);
+      }
+
+      // Global concurrency still requires a DB query — other workers may be running workflows too.
+      if (queue.concurrency() != null) {
+        String globalPendingQuery =
             """
-              SELECT executor_id, COUNT(*) as task_count
+              SELECT COUNT(*)
               FROM "%s".workflow_status
               WHERE queue_name = ? AND status = ?
             """
                 .formatted(ctx.schema());
         if (partitionKey != null) {
-          pendingQuery += " AND queue_partition_key = ?";
+          globalPendingQuery += " AND queue_partition_key = ?";
         }
-        pendingQuery += " GROUP BY executor_id";
 
-        Map<String, Integer> pendingWorkflows = new HashMap<>();
-        try (PreparedStatement ps = connection.prepareStatement(pendingQuery)) {
+        int globalPendingWorkflows = 0;
+        try (PreparedStatement ps = connection.prepareStatement(globalPendingQuery)) {
           ps.setString(1, queue.name());
           ps.setString(2, WorkflowState.PENDING.name());
           if (partitionKey != null) {
@@ -107,70 +116,38 @@ public class QueuesDAO {
           }
 
           try (ResultSet rs = ps.executeQuery()) {
-            while (rs.next()) {
-              var executor = rs.getString("executor_id");
-              var count = rs.getInt("task_count");
-              pendingWorkflows.put(executor, count);
+            if (rs.next()) {
+              globalPendingWorkflows = rs.getInt(1);
             }
           }
         }
 
-        int localPendingWorkflows = pendingWorkflows.getOrDefault(executorId, 0);
-
-        if (queue.workerConcurrency() != null) {
-          if (localPendingWorkflows > queue.workerConcurrency()) {
-            logger.warn(
-                "Local pending workflows ({}) on queue {} exceeds worker concurrency limit ({})",
-                localPendingWorkflows,
-                queue.name(),
-                queue.workerConcurrency());
-          }
-          maxTasks = Math.max(queue.workerConcurrency() - localPendingWorkflows, 0);
+        if (globalPendingWorkflows > queue.concurrency()) {
+          logger.warn(
+              "Total pending workflows ({}) on queue {} exceeds the global concurrency limit ({})",
+              globalPendingWorkflows,
+              queue.name(),
+              queue.concurrency());
         }
 
-        if (queue.concurrency() != null) {
-          var globalPendingWorkflows = 0;
-          for (var count : pendingWorkflows.values()) {
-            globalPendingWorkflows += count;
-          }
-
-          if (globalPendingWorkflows > queue.concurrency()) {
-            logger.warn(
-                "Total pending workflows ({}) on queue {} exceeds the global concurrency limit ({})",
-                globalPendingWorkflows,
-                queue.name(),
-                queue.concurrency());
-          }
-
-          int availableTasks = Math.max(0, queue.concurrency() - globalPendingWorkflows);
-          if (availableTasks < maxTasks) {
-            maxTasks = availableTasks;
-          }
-        }
-      }
-
-      if (maxTasks <= 0) {
-        return new ArrayList<>();
+        int availableTasks = Math.max(0, queue.concurrency() - globalPendingWorkflows);
+        maxTasks = Math.min(maxTasks, availableTasks);
       }
 
       var query =
           """
-              SELECT workflow_uuid
-              FROM "%s".workflow_status
-              WHERE queue_name = ?
-                AND status = ?
-                AND (application_version = ? OR application_version IS NULL)
+            SELECT workflow_uuid
+            FROM "%s".workflow_status
+            WHERE queue_name = ?
+              AND status = ?
+              AND (application_version = ? OR application_version IS NULL)
           """
               .formatted(ctx.schema());
       if (partitionKey != null) {
         query += " AND queue_partition_key = ?";
       }
 
-      if (queue.priorityEnabled()) {
-        query += " ORDER BY priority ASC, created_at ASC";
-      } else {
-        query += " ORDER BY created_at ASC";
-      }
+      query += " ORDER BY priority ASC, created_at ASC";
 
       if (queue.concurrency() == null) {
         query += " FOR UPDATE SKIP LOCKED";
@@ -178,7 +155,9 @@ public class QueuesDAO {
         query += " FOR UPDATE NOWAIT";
       }
 
-      query += " LIMIT %d".formatted(maxTasks);
+      if (maxTasks != Integer.MAX_VALUE) {
+        query += " LIMIT %d".formatted(maxTasks);
+      }
 
       List<String> dequeuedWorkflowIds = new ArrayList<>();
       try (var ps = connection.prepareStatement(query)) {
@@ -203,27 +182,30 @@ public class QueuesDAO {
             queue.name());
       }
 
-      var now = System.currentTimeMillis();
-      List<String> updatedWorkflowIds = new ArrayList<>();
       String updateQuery =
           """
-        UPDATE "%s".workflow_status
-        SET status = ?,
-            application_version = ?,
-            executor_id = ?,
-            started_at_epoch_ms = ?,
-            workflow_deadline_epoch_ms = CASE
-                WHEN workflow_timeout_ms IS NOT NULL AND workflow_deadline_epoch_ms IS NULL
-                THEN (EXTRACT(epoch FROM now()) * 1000)::bigint + workflow_timeout_ms
-                ELSE workflow_deadline_epoch_ms
-            END
-        WHERE workflow_uuid = ?
+            UPDATE "%s".workflow_status
+            SET status = ?,
+                application_version = ?,
+                executor_id = ?,
+                started_at_epoch_ms = ?,
+                rate_limited = ?,
+                workflow_deadline_epoch_ms = CASE
+                    WHEN workflow_timeout_ms IS NOT NULL AND workflow_deadline_epoch_ms IS NULL
+                    THEN (EXTRACT(epoch FROM now()) * 1000)::bigint + workflow_timeout_ms
+                    ELSE workflow_deadline_epoch_ms
+                END
+            WHERE workflow_uuid = ?
+              AND status = ?
           """
               .formatted(ctx.schema());
 
+      List<String> updatedWorkflowIds = new ArrayList<>();
       try (var ps = connection.prepareStatement(updateQuery)) {
+        var now = System.currentTimeMillis();
+        var hasRateLimit = queue.rateLimit() != null;
         for (var id : dequeuedWorkflowIds) {
-          if (queue.rateLimit() != null) {
+          if (hasRateLimit) {
             if (updatedWorkflowIds.size() + numRecentQueries >= queue.rateLimit().limit()) {
               break;
             }
@@ -233,9 +215,12 @@ public class QueuesDAO {
           ps.setString(2, appVersion);
           ps.setString(3, executorId);
           ps.setLong(4, now);
-          ps.setString(5, id);
-          ps.executeUpdate();
-          updatedWorkflowIds.add(id);
+          ps.setBoolean(5, hasRateLimit);
+          ps.setString(6, id);
+          ps.setString(7, WorkflowState.ENQUEUED.name());
+          if (ps.executeUpdate() > 0) {
+            updatedWorkflowIds.add(id);
+          }
         }
       }
 

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -106,11 +106,15 @@ public class DBOSExecutor implements AutoCloseable {
     }
   }
 
-  private static final ThreadLocal<Consumer<Invocation>> hookHolder = new ThreadLocal<>();
+  private record QueueBucket(String queueName, String partitionKey) {}
+
+  private static final ThreadLocal<Consumer<Invocation>> HOOK_HOLDER = new ThreadLocal<>();
+  private static final QueueBucket NO_QUEUE = new QueueBucket(null, null);
 
   private final DBOSConfig config;
   private final DBOSSerializer serializer;
   private final AtomicBoolean isRunning = new AtomicBoolean(false);
+  private final ConcurrentHashMap<String, QueueBucket> activeWorkflows = new ConcurrentHashMap<>();
 
   private boolean dbosCloud;
   private String appVersion;
@@ -122,7 +126,6 @@ public class DBOSExecutor implements AutoCloseable {
   private Map<String, RegisteredWorkflowInstance> instanceMap;
   private Map<String, RegisteredWorkflow> internalWorkflowMap;
   private Map<String, Queue> queueMap;
-  private ConcurrentHashMap<String, Boolean> workflowsInProgress = new ConcurrentHashMap<>();
 
   private SystemDatabase systemDatabase;
   private QueueService queueService;
@@ -460,6 +463,11 @@ public class DBOSExecutor implements AutoCloseable {
           message,
           metadata);
     }
+  }
+
+  public long queueActiveCount(String queueName, String partitionKey) {
+    var target = new QueueBucket(queueName, partitionKey);
+    return (int) activeWorkflows.values().stream().filter(target::equals).count();
   }
 
   // DBOS / DBOSClient API methods
@@ -923,18 +931,7 @@ public class DBOSExecutor implements AutoCloseable {
 
     var options =
         new ExecutionOptions(
-            workflowId,
-            null,
-            null,
-            queueName,
-            null,
-            null,
-            null,
-            null,
-            latestAppVersion,
-            false,
-            false,
-            null);
+            workflowId, null, null, queueName, null, null, null, null, latestAppVersion, null);
     enqueueWorkflow(
         workflowName,
         className,
@@ -1125,7 +1122,7 @@ public class DBOSExecutor implements AutoCloseable {
     Objects.requireNonNull(step, "step must not be null");
     Objects.requireNonNull(options, "options must not be null");
 
-    var hook = hookHolder.get();
+    var hook = HOOK_HOLDER.get();
     if (hook != null) {
       throw new RuntimeException("@Step functions cannot be called from the startWorkflow lambda");
     }
@@ -1236,7 +1233,7 @@ public class DBOSExecutor implements AutoCloseable {
 
   // helper method to validate that @Workflow methods are not invoked from the startWorkflow lambda
   public void validateNonWorkflowInvocation() {
-    var hook = hookHolder.get();
+    var hook = HOOK_HOLDER.get();
     if (hook != null) {
       throw new RuntimeException("Only @Workflow functions may run in this context");
     }
@@ -1251,7 +1248,7 @@ public class DBOSExecutor implements AutoCloseable {
 
     // If the hook holder is set, we're invoking the workflow from startWorkflow. In this case,
     // provide the workflow invocation info and return a default value without execution
-    var hook = hookHolder.get();
+    var hook = HOOK_HOLDER.get();
     if (hook != null) {
       hook.accept(new Invocation(this, workflowName, className, instanceName, args));
       var type = method.getReturnType();
@@ -1311,7 +1308,7 @@ public class DBOSExecutor implements AutoCloseable {
    */
   public <T, E extends Exception> Invocation captureInvocation(ThrowingSupplier<T, E> wfLambda) {
     AtomicReference<Invocation> capturedInvocation = new AtomicReference<>();
-    DBOSExecutor.hookHolder.set(
+    DBOSExecutor.HOOK_HOLDER.set(
         (invocation) -> {
           if (!capturedInvocation.compareAndSet(null, invocation)) {
             throw new RuntimeException("Only one @Workflow can be called in the captured lambda");
@@ -1322,7 +1319,7 @@ public class DBOSExecutor implements AutoCloseable {
     } catch (Exception e) {
       throw new RuntimeException(e);
     } finally {
-      DBOSExecutor.hookHolder.remove();
+      DBOSExecutor.HOOK_HOLDER.remove();
     }
     var invocation =
         Objects.requireNonNull(
@@ -1390,8 +1387,6 @@ public class DBOSExecutor implements AutoCloseable {
             options != null ? options.queuePartitionKey() : null,
             options != null ? options.delay() : null,
             options != null ? options.appVersion() : null,
-            false,
-            false,
             null);
     return executeWorkflow(workflow, args, execOptions, parent);
   }
@@ -1453,8 +1448,12 @@ public class DBOSExecutor implements AutoCloseable {
     var options =
         new ExecutionOptions(workflowId, status.timeout(), status.deadline())
             .withSerialization(status.serialization());
-    if (isRecoveryRequest) options = options.asRecoveryRequest();
-    if (isDequeuedRequest) options = options.asDequeuedRequest();
+    if (isRecoveryRequest) {
+      options = options.asRecoveryRequest();
+    }
+    if (isDequeuedRequest) {
+      options = options.asDequeuedRequest(status.queueName(), status.queuePartitionKey());
+    }
     return executeWorkflow(workflow, inputs, options, null);
   }
 
@@ -1561,7 +1560,7 @@ public class DBOSExecutor implements AutoCloseable {
 
     Integer maxRetries = workflow.maxRecoveryAttempts() > 0 ? workflow.maxRecoveryAttempts() : null;
 
-    if (options.queueName() != null) {
+    if (options.queueName() != null && !options.isDequeuedRequest()) {
 
       validateQueue(options.queueName(), options.queuePartitionKey());
 
@@ -1646,8 +1645,13 @@ public class DBOSExecutor implements AutoCloseable {
     Supplier<T> task =
         () -> {
           DBOSContextHolder.clear();
-          var res = workflowsInProgress.putIfAbsent(workflowId, true);
-          if (res != null) throw new DBOSWorkflowExecutionConflictException(workflowId);
+          var bucket =
+              finalOptions.isDequeuedRequest()
+                  ? new QueueBucket(finalOptions.queueName(), finalOptions.queuePartitionKey())
+                  : NO_QUEUE;
+          if (activeWorkflows.putIfAbsent(workflowId, bucket) != null) {
+            throw new DBOSWorkflowExecutionConflictException(workflowId);
+          }
           try {
             logger.debug(
                 "executeWorkflow task {}({}) {}",
@@ -1707,7 +1711,7 @@ public class DBOSExecutor implements AutoCloseable {
             throw e;
           } finally {
             DBOSContextHolder.clear();
-            workflowsInProgress.remove(workflowId);
+            activeWorkflows.remove(workflowId);
           }
         };
 

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -467,7 +467,7 @@ public class DBOSExecutor implements AutoCloseable {
 
   public long queueActiveCount(String queueName, String partitionKey) {
     var target = new QueueBucket(queueName, partitionKey);
-    return (int) activeWorkflows.values().stream().filter(target::equals).count();
+    return activeWorkflows.values().stream().filter(target::equals).count();
   }
 
   // DBOS / DBOSClient API methods

--- a/transact/src/main/java/dev/dbos/transact/execution/ExecutionOptions.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/ExecutionOptions.java
@@ -21,9 +21,11 @@ public record ExecutionOptions(
     String queuePartitionKey,
     Duration delay,
     String appVersion,
+    String serialization,
+    // True when re-executing a workflow that previously crashed; skips re-enqueue guards.
     boolean isRecoveryRequest,
-    boolean isDequeuedRequest,
-    String serialization) {
+    // True when the workflow was pulled off a queue by this executor, not started directly.
+    boolean isDequeuedRequest) {
   public ExecutionOptions {
     if (nullableIsEmpty(workflowId)) {
       throw new IllegalArgumentException("workflowId must not be empty");
@@ -58,24 +60,38 @@ public record ExecutionOptions(
     }
   }
 
+  public ExecutionOptions(
+      String workflowId,
+      Timeout timeout,
+      Instant deadline,
+      String queueName,
+      String deduplicationId,
+      Integer priority,
+      String queuePartitionKey,
+      Duration delay,
+      String appVersion,
+      String serialization) {
+    this(
+        workflowId,
+        timeout,
+        deadline,
+        queueName,
+        deduplicationId,
+        priority,
+        queuePartitionKey,
+        delay,
+        appVersion,
+        serialization,
+        false,
+        false);
+  }
+
   public ExecutionOptions(String workflowId) {
-    this(workflowId, null, null, null, null, null, null, null, null, false, false, null);
+    this(workflowId, null, null, null, null, null, null, null, null, null);
   }
 
   public ExecutionOptions(String workflowId, Duration timeout, Instant deadline) {
-    this(
-        workflowId,
-        Timeout.of(timeout),
-        deadline,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        false,
-        false,
-        null);
+    this(workflowId, Timeout.of(timeout), deadline, null, null, null, null, null, null, null);
   }
 
   public ExecutionOptions asRecoveryRequest() {
@@ -89,25 +105,25 @@ public record ExecutionOptions(
         this.queuePartitionKey,
         this.delay,
         this.appVersion,
+        this.serialization,
         true,
-        false,
-        this.serialization);
+        false);
   }
 
-  public ExecutionOptions asDequeuedRequest() {
+  public ExecutionOptions asDequeuedRequest(String queueName, String partitionKey) {
     return new ExecutionOptions(
         this.workflowId,
         this.timeout,
         this.deadline,
-        this.queueName,
+        queueName,
         this.deduplicationId,
         this.priority,
-        this.queuePartitionKey,
+        queuePartitionKey,
         this.delay,
         this.appVersion,
+        this.serialization,
         false,
-        true,
-        this.serialization);
+        true);
   }
 
   public ExecutionOptions withSerialization(String serialization) {
@@ -121,9 +137,9 @@ public record ExecutionOptions(
         this.queuePartitionKey,
         this.delay,
         this.appVersion,
+        serialization,
         this.isRecoveryRequest,
-        this.isDequeuedRequest,
-        serialization);
+        this.isDequeuedRequest);
   }
 
   public ExecutionOptions withPriority(Integer priority) {
@@ -137,9 +153,9 @@ public record ExecutionOptions(
         this.queuePartitionKey,
         this.delay,
         this.appVersion,
+        this.serialization,
         this.isRecoveryRequest,
-        this.isDequeuedRequest,
-        this.serialization);
+        this.isDequeuedRequest);
   }
 
   public ExecutionOptions withAppVersion(String appVersion) {
@@ -153,9 +169,9 @@ public record ExecutionOptions(
         this.queuePartitionKey,
         this.delay,
         appVersion,
+        this.serialization,
         this.isRecoveryRequest,
-        this.isDequeuedRequest,
-        this.serialization);
+        this.isDequeuedRequest);
   }
 
   public Duration timeoutDuration() {

--- a/transact/src/main/java/dev/dbos/transact/execution/QueueService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/QueueService.java
@@ -166,8 +166,10 @@ public class QueueService implements AutoCloseable {
     private void processPartition(String partition) {
       var partitionLog = Objects.requireNonNullElse(partition, "<null>");
       if (!paused.get()) {
+        long localRunningCount = dbosExecutor.queueActiveCount(queue.name(), partition);
         var workflowIds =
-            systemDatabase.getAndStartQueuedWorkflows(queue, executorId, appVersion, partition);
+            systemDatabase.startQueuedWorkflows(
+                queue, executorId, appVersion, partition, localRunningCount);
         if (!workflowIds.isEmpty()) {
           logger.debug(
               "Retrieved {} workflows from {} partition of queue {}",

--- a/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import dev.dbos.transact.Constants;
 import dev.dbos.transact.config.DBOSConfig;
+import dev.dbos.transact.database.dao.QueuesDAO;
 import dev.dbos.transact.exceptions.DBOSMaxRecoveryAttemptsExceededException;
 import dev.dbos.transact.exceptions.DBOSQueueDuplicatedException;
 import dev.dbos.transact.migrations.MigrationManager;
@@ -32,15 +33,18 @@ import dev.dbos.transact.workflow.WorkflowDelay;
 import dev.dbos.transact.workflow.WorkflowSchedule;
 import dev.dbos.transact.workflow.WorkflowState;
 
+import java.io.PrintWriter;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import javax.sql.DataSource;
 
@@ -1741,5 +1745,397 @@ public class SystemDatabaseTest {
     assertEquals(20, fetched.rateLimit().limit());
     assertEquals(Duration.ofSeconds(30), fetched.rateLimit().period());
     assertEquals(Duration.ofSeconds(5), fetched.pollingInterval());
+  }
+
+  // --- Transaction isolation tests ---
+
+  /**
+   * Wraps a real DataSource and records the isolation level passed to {@link
+   * Connection#setTransactionIsolation} on each connection it vends.
+   */
+  private static class IsolationRecordingDataSource implements DataSource {
+    private final DataSource delegate;
+    int lastIsolationLevel = Connection.TRANSACTION_READ_COMMITTED; // postgres default
+
+    IsolationRecordingDataSource(DataSource delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+      Connection real = delegate.getConnection();
+      return new java.sql.Connection() {
+        // Intercept setTransactionIsolation; delegate everything else.
+        @Override
+        public void setTransactionIsolation(int level) throws SQLException {
+          lastIsolationLevel = level;
+          real.setTransactionIsolation(level);
+        }
+
+        @Override
+        public int getTransactionIsolation() throws SQLException {
+          return real.getTransactionIsolation();
+        }
+
+        @Override
+        public void setAutoCommit(boolean a) throws SQLException {
+          real.setAutoCommit(a);
+        }
+
+        @Override
+        public boolean getAutoCommit() throws SQLException {
+          return real.getAutoCommit();
+        }
+
+        @Override
+        public void commit() throws SQLException {
+          real.commit();
+        }
+
+        @Override
+        public void rollback() throws SQLException {
+          real.rollback();
+        }
+
+        @Override
+        public void close() throws SQLException {
+          real.close();
+        }
+
+        @Override
+        public boolean isClosed() throws SQLException {
+          return real.isClosed();
+        }
+
+        @Override
+        public java.sql.Statement createStatement() throws SQLException {
+          return real.createStatement();
+        }
+
+        @Override
+        public java.sql.PreparedStatement prepareStatement(String s) throws SQLException {
+          return real.prepareStatement(s);
+        }
+
+        @Override
+        public java.sql.CallableStatement prepareCall(String s) throws SQLException {
+          return real.prepareCall(s);
+        }
+
+        @Override
+        public String nativeSQL(String s) throws SQLException {
+          return real.nativeSQL(s);
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() throws SQLException {
+          return real.getMetaData();
+        }
+
+        @Override
+        public void setReadOnly(boolean r) throws SQLException {
+          real.setReadOnly(r);
+        }
+
+        @Override
+        public boolean isReadOnly() throws SQLException {
+          return real.isReadOnly();
+        }
+
+        @Override
+        public void setCatalog(String c) throws SQLException {
+          real.setCatalog(c);
+        }
+
+        @Override
+        public String getCatalog() throws SQLException {
+          return real.getCatalog();
+        }
+
+        @Override
+        public java.sql.SQLWarning getWarnings() throws SQLException {
+          return real.getWarnings();
+        }
+
+        @Override
+        public void clearWarnings() throws SQLException {
+          real.clearWarnings();
+        }
+
+        @Override
+        public java.sql.Statement createStatement(int r, int c) throws SQLException {
+          return real.createStatement(r, c);
+        }
+
+        @Override
+        public java.sql.PreparedStatement prepareStatement(String s, int r, int c)
+            throws SQLException {
+          return real.prepareStatement(s, r, c);
+        }
+
+        @Override
+        public java.sql.CallableStatement prepareCall(String s, int r, int c) throws SQLException {
+          return real.prepareCall(s, r, c);
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() throws SQLException {
+          return real.getTypeMap();
+        }
+
+        @Override
+        public void setTypeMap(Map<String, Class<?>> m) throws SQLException {
+          real.setTypeMap(m);
+        }
+
+        @Override
+        public void setHoldability(int h) throws SQLException {
+          real.setHoldability(h);
+        }
+
+        @Override
+        public int getHoldability() throws SQLException {
+          return real.getHoldability();
+        }
+
+        @Override
+        public java.sql.Savepoint setSavepoint() throws SQLException {
+          return real.setSavepoint();
+        }
+
+        @Override
+        public java.sql.Savepoint setSavepoint(String n) throws SQLException {
+          return real.setSavepoint(n);
+        }
+
+        @Override
+        public void rollback(java.sql.Savepoint s) throws SQLException {
+          real.rollback(s);
+        }
+
+        @Override
+        public void releaseSavepoint(java.sql.Savepoint s) throws SQLException {
+          real.releaseSavepoint(s);
+        }
+
+        @Override
+        public java.sql.Statement createStatement(int r, int c, int h) throws SQLException {
+          return real.createStatement(r, c, h);
+        }
+
+        @Override
+        public java.sql.PreparedStatement prepareStatement(String s, int r, int c, int h)
+            throws SQLException {
+          return real.prepareStatement(s, r, c, h);
+        }
+
+        @Override
+        public java.sql.CallableStatement prepareCall(String s, int r, int c, int h)
+            throws SQLException {
+          return real.prepareCall(s, r, c, h);
+        }
+
+        @Override
+        public java.sql.PreparedStatement prepareStatement(String s, int[] ci) throws SQLException {
+          return real.prepareStatement(s, ci);
+        }
+
+        @Override
+        public java.sql.PreparedStatement prepareStatement(String s, String[] cn)
+            throws SQLException {
+          return real.prepareStatement(s, cn);
+        }
+
+        @Override
+        public java.sql.PreparedStatement prepareStatement(String s, int ag) throws SQLException {
+          return real.prepareStatement(s, ag);
+        }
+
+        @Override
+        public java.sql.Clob createClob() throws SQLException {
+          return real.createClob();
+        }
+
+        @Override
+        public java.sql.Blob createBlob() throws SQLException {
+          return real.createBlob();
+        }
+
+        @Override
+        public java.sql.NClob createNClob() throws SQLException {
+          return real.createNClob();
+        }
+
+        @Override
+        public java.sql.SQLXML createSQLXML() throws SQLException {
+          return real.createSQLXML();
+        }
+
+        @Override
+        public boolean isValid(int t) throws SQLException {
+          return real.isValid(t);
+        }
+
+        @Override
+        public void setClientInfo(String n, String v) throws java.sql.SQLClientInfoException {
+          try {
+            real.setClientInfo(n, v);
+          } catch (java.sql.SQLClientInfoException e) {
+            throw e;
+          }
+        }
+
+        @Override
+        public void setClientInfo(java.util.Properties p) throws java.sql.SQLClientInfoException {
+          try {
+            real.setClientInfo(p);
+          } catch (java.sql.SQLClientInfoException e) {
+            throw e;
+          }
+        }
+
+        @Override
+        public String getClientInfo(String n) throws SQLException {
+          return real.getClientInfo(n);
+        }
+
+        @Override
+        public java.util.Properties getClientInfo() throws SQLException {
+          return real.getClientInfo();
+        }
+
+        @Override
+        public java.sql.Array createArrayOf(String t, Object[] e) throws SQLException {
+          return real.createArrayOf(t, e);
+        }
+
+        @Override
+        public java.sql.Struct createStruct(String t, Object[] a) throws SQLException {
+          return real.createStruct(t, a);
+        }
+
+        @Override
+        public void setSchema(String s) throws SQLException {
+          real.setSchema(s);
+        }
+
+        @Override
+        public String getSchema() throws SQLException {
+          return real.getSchema();
+        }
+
+        @Override
+        public void abort(java.util.concurrent.Executor e) throws SQLException {
+          real.abort(e);
+        }
+
+        @Override
+        public void setNetworkTimeout(java.util.concurrent.Executor e, int ms) throws SQLException {
+          real.setNetworkTimeout(e, ms);
+        }
+
+        @Override
+        public int getNetworkTimeout() throws SQLException {
+          return real.getNetworkTimeout();
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> i) throws SQLException {
+          return real.unwrap(i);
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> i) throws SQLException {
+          return real.isWrapperFor(i);
+        }
+      };
+    }
+
+    @Override
+    public Connection getConnection(String u, String p) throws SQLException {
+      return delegate.getConnection(u, p);
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+      return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter w) throws SQLException {
+      delegate.setLogWriter(w);
+    }
+
+    @Override
+    public void setLoginTimeout(int s) throws SQLException {
+      delegate.setLoginTimeout(s);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+      return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+      return delegate.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> i) throws SQLException {
+      return delegate.unwrap(i);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> i) throws SQLException {
+      return delegate.isWrapperFor(i);
+    }
+  }
+
+  private DbContext recordingCtx(IsolationRecordingDataSource ds) {
+    String schema = SystemDatabase.sanitizeSchema(dbosConfig.databaseSchema());
+    return new DbContext(ds, schema, null, () -> false);
+  }
+
+  @Test
+  public void testWorkerConcurrencyOnlyUsesReadCommitted() throws SQLException {
+    // workerConcurrency only → local in-memory tracking, no global state → READ COMMITTED
+    Queue queue = new Queue("iso-wc").withWorkerConcurrency(2);
+    var ds = new IsolationRecordingDataSource(dataSource);
+
+    QueuesDAO.startQueuedWorkflows(recordingCtx(ds), queue, "exec", "v1", null, 0);
+
+    assertEquals(
+        Connection.TRANSACTION_READ_COMMITTED,
+        ds.lastIsolationLevel,
+        "workerConcurrency-only queue must not escalate to REPEATABLE READ");
+  }
+
+  @Test
+  public void testGlobalConcurrencyUsesRepeatableRead() throws SQLException {
+    // concurrency (global) → needs a consistent snapshot across workers → REPEATABLE READ
+    Queue queue = new Queue("iso-gc").withConcurrency(3);
+    var ds = new IsolationRecordingDataSource(dataSource);
+
+    QueuesDAO.startQueuedWorkflows(recordingCtx(ds), queue, "exec", "v1", null, 0);
+
+    assertEquals(
+        Connection.TRANSACTION_REPEATABLE_READ,
+        ds.lastIsolationLevel,
+        "global-concurrency queue must use REPEATABLE READ");
+  }
+
+  @Test
+  public void testRateLimitUsesRepeatableRead() throws SQLException {
+    // rateLimit → count must be consistent across concurrent dequeue attempts → REPEATABLE READ
+    Queue queue = new Queue("iso-rl").withRateLimit(5, Duration.ofSeconds(1));
+    var ds = new IsolationRecordingDataSource(dataSource);
+
+    QueuesDAO.startQueuedWorkflows(recordingCtx(ds), queue, "exec", "v1", null, 0);
+
+    assertEquals(
+        Connection.TRANSACTION_REPEATABLE_READ,
+        ds.lastIsolationLevel,
+        "rate-limited queue must use REPEATABLE READ");
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -34,6 +34,7 @@ import dev.dbos.transact.workflow.WorkflowSchedule;
 import dev.dbos.transact.workflow.WorkflowState;
 
 import java.io.PrintWriter;
+import java.lang.reflect.Proxy;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
@@ -1755,7 +1756,7 @@ public class SystemDatabaseTest {
    */
   private static class IsolationRecordingDataSource implements DataSource {
     private final DataSource delegate;
-    int lastIsolationLevel = Connection.TRANSACTION_READ_COMMITTED; // postgres default
+    volatile int lastIsolationLevel = Connection.TRANSACTION_READ_COMMITTED; // postgres default
 
     IsolationRecordingDataSource(DataSource delegate) {
       this.delegate = delegate;
@@ -1764,291 +1765,20 @@ public class SystemDatabaseTest {
     @Override
     public Connection getConnection() throws SQLException {
       Connection real = delegate.getConnection();
-      return new java.sql.Connection() {
-        // Intercept setTransactionIsolation; delegate everything else.
-        @Override
-        public void setTransactionIsolation(int level) throws SQLException {
-          lastIsolationLevel = level;
-          real.setTransactionIsolation(level);
-        }
-
-        @Override
-        public int getTransactionIsolation() throws SQLException {
-          return real.getTransactionIsolation();
-        }
-
-        @Override
-        public void setAutoCommit(boolean a) throws SQLException {
-          real.setAutoCommit(a);
-        }
-
-        @Override
-        public boolean getAutoCommit() throws SQLException {
-          return real.getAutoCommit();
-        }
-
-        @Override
-        public void commit() throws SQLException {
-          real.commit();
-        }
-
-        @Override
-        public void rollback() throws SQLException {
-          real.rollback();
-        }
-
-        @Override
-        public void close() throws SQLException {
-          real.close();
-        }
-
-        @Override
-        public boolean isClosed() throws SQLException {
-          return real.isClosed();
-        }
-
-        @Override
-        public java.sql.Statement createStatement() throws SQLException {
-          return real.createStatement();
-        }
-
-        @Override
-        public java.sql.PreparedStatement prepareStatement(String s) throws SQLException {
-          return real.prepareStatement(s);
-        }
-
-        @Override
-        public java.sql.CallableStatement prepareCall(String s) throws SQLException {
-          return real.prepareCall(s);
-        }
-
-        @Override
-        public String nativeSQL(String s) throws SQLException {
-          return real.nativeSQL(s);
-        }
-
-        @Override
-        public DatabaseMetaData getMetaData() throws SQLException {
-          return real.getMetaData();
-        }
-
-        @Override
-        public void setReadOnly(boolean r) throws SQLException {
-          real.setReadOnly(r);
-        }
-
-        @Override
-        public boolean isReadOnly() throws SQLException {
-          return real.isReadOnly();
-        }
-
-        @Override
-        public void setCatalog(String c) throws SQLException {
-          real.setCatalog(c);
-        }
-
-        @Override
-        public String getCatalog() throws SQLException {
-          return real.getCatalog();
-        }
-
-        @Override
-        public java.sql.SQLWarning getWarnings() throws SQLException {
-          return real.getWarnings();
-        }
-
-        @Override
-        public void clearWarnings() throws SQLException {
-          real.clearWarnings();
-        }
-
-        @Override
-        public java.sql.Statement createStatement(int r, int c) throws SQLException {
-          return real.createStatement(r, c);
-        }
-
-        @Override
-        public java.sql.PreparedStatement prepareStatement(String s, int r, int c)
-            throws SQLException {
-          return real.prepareStatement(s, r, c);
-        }
-
-        @Override
-        public java.sql.CallableStatement prepareCall(String s, int r, int c) throws SQLException {
-          return real.prepareCall(s, r, c);
-        }
-
-        @Override
-        public Map<String, Class<?>> getTypeMap() throws SQLException {
-          return real.getTypeMap();
-        }
-
-        @Override
-        public void setTypeMap(Map<String, Class<?>> m) throws SQLException {
-          real.setTypeMap(m);
-        }
-
-        @Override
-        public void setHoldability(int h) throws SQLException {
-          real.setHoldability(h);
-        }
-
-        @Override
-        public int getHoldability() throws SQLException {
-          return real.getHoldability();
-        }
-
-        @Override
-        public java.sql.Savepoint setSavepoint() throws SQLException {
-          return real.setSavepoint();
-        }
-
-        @Override
-        public java.sql.Savepoint setSavepoint(String n) throws SQLException {
-          return real.setSavepoint(n);
-        }
-
-        @Override
-        public void rollback(java.sql.Savepoint s) throws SQLException {
-          real.rollback(s);
-        }
-
-        @Override
-        public void releaseSavepoint(java.sql.Savepoint s) throws SQLException {
-          real.releaseSavepoint(s);
-        }
-
-        @Override
-        public java.sql.Statement createStatement(int r, int c, int h) throws SQLException {
-          return real.createStatement(r, c, h);
-        }
-
-        @Override
-        public java.sql.PreparedStatement prepareStatement(String s, int r, int c, int h)
-            throws SQLException {
-          return real.prepareStatement(s, r, c, h);
-        }
-
-        @Override
-        public java.sql.CallableStatement prepareCall(String s, int r, int c, int h)
-            throws SQLException {
-          return real.prepareCall(s, r, c, h);
-        }
-
-        @Override
-        public java.sql.PreparedStatement prepareStatement(String s, int[] ci) throws SQLException {
-          return real.prepareStatement(s, ci);
-        }
-
-        @Override
-        public java.sql.PreparedStatement prepareStatement(String s, String[] cn)
-            throws SQLException {
-          return real.prepareStatement(s, cn);
-        }
-
-        @Override
-        public java.sql.PreparedStatement prepareStatement(String s, int ag) throws SQLException {
-          return real.prepareStatement(s, ag);
-        }
-
-        @Override
-        public java.sql.Clob createClob() throws SQLException {
-          return real.createClob();
-        }
-
-        @Override
-        public java.sql.Blob createBlob() throws SQLException {
-          return real.createBlob();
-        }
-
-        @Override
-        public java.sql.NClob createNClob() throws SQLException {
-          return real.createNClob();
-        }
-
-        @Override
-        public java.sql.SQLXML createSQLXML() throws SQLException {
-          return real.createSQLXML();
-        }
-
-        @Override
-        public boolean isValid(int t) throws SQLException {
-          return real.isValid(t);
-        }
-
-        @Override
-        public void setClientInfo(String n, String v) throws java.sql.SQLClientInfoException {
-          try {
-            real.setClientInfo(n, v);
-          } catch (java.sql.SQLClientInfoException e) {
-            throw e;
-          }
-        }
-
-        @Override
-        public void setClientInfo(java.util.Properties p) throws java.sql.SQLClientInfoException {
-          try {
-            real.setClientInfo(p);
-          } catch (java.sql.SQLClientInfoException e) {
-            throw e;
-          }
-        }
-
-        @Override
-        public String getClientInfo(String n) throws SQLException {
-          return real.getClientInfo(n);
-        }
-
-        @Override
-        public java.util.Properties getClientInfo() throws SQLException {
-          return real.getClientInfo();
-        }
-
-        @Override
-        public java.sql.Array createArrayOf(String t, Object[] e) throws SQLException {
-          return real.createArrayOf(t, e);
-        }
-
-        @Override
-        public java.sql.Struct createStruct(String t, Object[] a) throws SQLException {
-          return real.createStruct(t, a);
-        }
-
-        @Override
-        public void setSchema(String s) throws SQLException {
-          real.setSchema(s);
-        }
-
-        @Override
-        public String getSchema() throws SQLException {
-          return real.getSchema();
-        }
-
-        @Override
-        public void abort(java.util.concurrent.Executor e) throws SQLException {
-          real.abort(e);
-        }
-
-        @Override
-        public void setNetworkTimeout(java.util.concurrent.Executor e, int ms) throws SQLException {
-          real.setNetworkTimeout(e, ms);
-        }
-
-        @Override
-        public int getNetworkTimeout() throws SQLException {
-          return real.getNetworkTimeout();
-        }
-
-        @Override
-        public <T> T unwrap(Class<T> i) throws SQLException {
-          return real.unwrap(i);
-        }
-
-        @Override
-        public boolean isWrapperFor(Class<?> i) throws SQLException {
-          return real.isWrapperFor(i);
-        }
-      };
+      return (Connection)
+          Proxy.newProxyInstance(
+              Connection.class.getClassLoader(),
+              new Class<?>[] {Connection.class},
+              (proxy, method, args) -> {
+                if ("setTransactionIsolation".equals(method.getName())) {
+                  lastIsolationLevel = (int) args[0];
+                }
+                try {
+                  return method.invoke(real, args);
+                } catch (java.lang.reflect.InvocationTargetException e) {
+                  throw e.getCause();
+                }
+              });
     }
 
     @Override

--- a/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
@@ -1139,7 +1139,7 @@ public class DynamicQueuesTest {
 
     ConcurrencyTestServiceImpl impl2 = new ConcurrencyTestServiceImpl();
     try (var dbos2 = new DBOS(dbosConfig.withExecutorId("executor2"))) {
-      dbos2.registerProxy(ConcurrencyTestService.class, impl2);
+      ConcurrencyTestService service2 = dbos2.registerProxy(ConcurrencyTestService.class, impl2);
       dbos2.launch();
 
       var qs2 = DBOSTestAccess.getQueueService(dbos2);
@@ -1152,8 +1152,8 @@ public class DynamicQueuesTest {
       for (int i = 0; i < workerConcurrency; i++) {
         final int fi = i;
         handles2.add(
-            dbos.startWorkflow(
-                () -> service.blockedWorkflow(fi),
+            dbos2.startWorkflow(
+                () -> service2.blockedWorkflow(fi),
                 new StartWorkflowOptions().withQueue("multi_exec_queue")));
       }
       impl2.wfSemaphore.acquire(workerConcurrency);
@@ -1162,8 +1162,8 @@ public class DynamicQueuesTest {
       }
 
       var extra =
-          dbos.startWorkflow(
-              () -> service.noopWorkflow(99),
+          dbos2.startWorkflow(
+              () -> service2.noopWorkflow(99),
               new StartWorkflowOptions().withQueue("multi_exec_queue"));
       Thread.sleep(2000);
       assertEquals(WorkflowState.ENQUEUED, extra.getStatus().status());

--- a/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
@@ -12,6 +12,7 @@ import dev.dbos.transact.DBOS;
 import dev.dbos.transact.DBOSTestAccess;
 import dev.dbos.transact.StartWorkflowOptions;
 import dev.dbos.transact.config.DBOSConfig;
+import dev.dbos.transact.exceptions.DBOSQueueDuplicatedException;
 import dev.dbos.transact.json.SerializationUtil;
 import dev.dbos.transact.utils.DBUtils;
 import dev.dbos.transact.utils.PgContainer;
@@ -1008,8 +1009,7 @@ public class DynamicQueuesTest {
             new StartWorkflowOptions("blocked").withQueue("test_queue"));
     var regularHandle =
         dbos.startWorkflow(
-            () -> service.noopWorkflow(42),
-            new StartWorkflowOptions().withQueue("test_queue"));
+            () -> service.noopWorkflow(42), new StartWorkflowOptions().withQueue("test_queue"));
 
     impl.wfSemaphore.acquire(1);
     assertEquals(WorkflowState.PENDING, blockedHandle.getStatus().status());
@@ -1094,11 +1094,15 @@ public class DynamicQueuesTest {
     var h1 =
         dbos.startWorkflow(
             () -> service.blockedWorkflow(0),
-            new StartWorkflowOptions().withQueue("test_queue").withTimeout(500, TimeUnit.MILLISECONDS));
+            new StartWorkflowOptions()
+                .withQueue("test_queue")
+                .withTimeout(500, TimeUnit.MILLISECONDS));
     var h2 =
         dbos.startWorkflow(
             () -> service.blockedWorkflow(1),
-            new StartWorkflowOptions().withQueue("test_queue").withTimeout(500, TimeUnit.MILLISECONDS));
+            new StartWorkflowOptions()
+                .withQueue("test_queue")
+                .withTimeout(500, TimeUnit.MILLISECONDS));
     var normalHandle =
         dbos.startWorkflow(
             () -> service.noopWorkflow(42),
@@ -1128,7 +1132,8 @@ public class DynamicQueuesTest {
     for (int i = 0; i < workerConcurrency; i++) {
       final int fi = i;
       dbos.startWorkflow(
-          () -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue("multi_exec_queue"));
+          () -> service.blockedWorkflow(fi),
+          new StartWorkflowOptions().withQueue("multi_exec_queue"));
     }
     impl1.wfSemaphore.acquire(workerConcurrency);
 
@@ -1171,6 +1176,93 @@ public class DynamicQueuesTest {
     }
 
     impl1.latch.countDown();
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testQueueChildWorkflow() throws Exception {
+    // A workflow can enqueue child workflows on a queue and await their results.
+    // With concurrency=3 and 4 children, the 4th waits for a slot.
+    QueueChildServiceImpl impl = new QueueChildServiceImpl(dbos);
+    QueueChildService service = dbos.registerProxy(QueueChildService.class, impl);
+    impl.setSelf(service);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    dbos.registerQueue("child_queue", QueueOptions.setConcurrency(3));
+
+    var handle =
+        dbos.startWorkflow(() -> service.parentWorkflow("a", "b"), new StartWorkflowOptions());
+    assertEquals("adbdadbd", handle.getResult());
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testQueueDeduplication() throws Exception {
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    qs.pause();
+    dbos.registerQueue("test_queue", QueueOptions.empty());
+
+    String deduplicationId = "my-dedup-id";
+    String wfid1 = "wf-dedup-1";
+
+    // Enqueue with a deduplication ID.
+    var h1 =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(1),
+            new StartWorkflowOptions(wfid1)
+                .withQueue("test_queue")
+                .withDeduplicationId(deduplicationId));
+    assertEquals(deduplicationId, h1.getStatus().deduplicationId());
+    assertEquals(WorkflowState.ENQUEUED, h1.getStatus().status());
+
+    // Same dedup ID with a different workflow ID → exception.
+    assertThrows(
+        DBOSQueueDuplicatedException.class,
+        () ->
+            dbos.startWorkflow(
+                () -> service.noopWorkflow(2),
+                new StartWorkflowOptions()
+                    .withQueue("test_queue")
+                    .withDeduplicationId(deduplicationId)));
+
+    // Re-enqueue the same workflow ID → idempotent, no exception.
+    var h1again =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(1),
+            new StartWorkflowOptions(wfid1)
+                .withQueue("test_queue")
+                .withDeduplicationId(deduplicationId));
+    assertEquals(wfid1, h1again.workflowId());
+
+    // Different dedup ID is fine.
+    var h2 =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(3),
+            new StartWorkflowOptions()
+                .withQueue("test_queue")
+                .withDeduplicationId("other-dedup-id"));
+
+    // Unpause and let both run.
+    qs.unpause();
+    assertEquals(1, (int) h1.getResult());
+    assertEquals(3, (int) h2.getResult());
+
+    // After completion the same dedup ID can be reused.
+    var h3 =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(4),
+            new StartWorkflowOptions()
+                .withQueue("test_queue")
+                .withDeduplicationId(deduplicationId));
+    assertEquals(4, (int) h3.getResult());
+
     assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
   }
 

--- a/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
 
 import com.zaxxer.hikari.HikariDataSource;
@@ -989,6 +990,188 @@ public class DynamicQueuesTest {
       assertEquals("oneone", h1.getResult());
       assertEquals(WorkflowState.ENQUEUED, h2.getStatus().status());
     }
+  }
+
+  @Test
+  public void testCancellingQueuedWorkflows() throws Exception {
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    dbos.registerQueue("test_queue", QueueOptions.setConcurrency(1));
+
+    var blockedHandle =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0),
+            new StartWorkflowOptions("blocked").withQueue("test_queue"));
+    var regularHandle =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(42),
+            new StartWorkflowOptions().withQueue("test_queue"));
+
+    impl.wfSemaphore.acquire(1);
+    assertEquals(WorkflowState.PENDING, blockedHandle.getStatus().status());
+    assertEquals(WorkflowState.ENQUEUED, regularHandle.getStatus().status());
+
+    dbos.cancelWorkflow("blocked");
+    assertEquals(WorkflowState.CANCELLED, blockedHandle.getStatus().status());
+    assertEquals(42, (int) regularHandle.getResult());
+
+    impl.latch.countDown();
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testResumingQueuedWorkflows() throws Exception {
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    dbos.registerQueue("test_queue", QueueOptions.setConcurrency(1));
+
+    var blockedHandle =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0), new StartWorkflowOptions().withQueue("test_queue"));
+    var regularHandle =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(99),
+            new StartWorkflowOptions("resumable").withQueue("test_queue"));
+
+    impl.wfSemaphore.acquire(1);
+    assertEquals(WorkflowState.ENQUEUED, regularHandle.getStatus().status());
+
+    var resumedHandle = dbos.<Integer, Exception>resumeWorkflow("resumable");
+    assertEquals(99, (int) resumedHandle.getResult());
+
+    impl.latch.countDown();
+    blockedHandle.getResult();
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testOneAtATimeWithWorkerConcurrency() throws Exception {
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    dbos.registerQueue("test_queue", QueueOptions.setWorkerConcurrency(1));
+
+    var h1 =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0), new StartWorkflowOptions().withQueue("test_queue"));
+    var h2 =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(1), new StartWorkflowOptions().withQueue("test_queue"));
+
+    impl.wfSemaphore.acquire(1);
+    Thread.sleep(2000);
+    assertEquals(WorkflowState.ENQUEUED, h2.getStatus().status());
+    assertEquals(1, impl.counter.get());
+
+    impl.latch.countDown();
+    assertEquals(0, h1.getResult());
+    assertEquals(1, h2.getResult());
+    assertEquals(1, impl.counter.get());
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testTimeoutQueue() throws Exception {
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    dbos.registerQueue("test_queue", QueueOptions.setConcurrency(1));
+
+    var h1 =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0),
+            new StartWorkflowOptions().withQueue("test_queue").withTimeout(500, TimeUnit.MILLISECONDS));
+    var h2 =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(1),
+            new StartWorkflowOptions().withQueue("test_queue").withTimeout(500, TimeUnit.MILLISECONDS));
+    var normalHandle =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(42),
+            new StartWorkflowOptions().withQueue("test_queue").withTimeout(10, TimeUnit.SECONDS));
+
+    assertThrows(Exception.class, h1::getResult);
+    assertThrows(Exception.class, h2::getResult);
+    assertEquals(42, (int) normalHandle.getResult());
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testMultipleExecutorWorkerConcurrency() throws Exception {
+    int workerConcurrency = 2;
+    int globalConcurrency = workerConcurrency * 2;
+
+    ConcurrencyTestServiceImpl impl1 = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl1);
+    dbos.launch();
+
+    var qs = DBOSTestAccess.getQueueService(dbos);
+    qs.setSpeedupForTest();
+    dbos.registerQueue(
+        "multi_exec_queue",
+        QueueOptions.setWorkerConcurrency(workerConcurrency).andConcurrency(globalConcurrency));
+
+    for (int i = 0; i < workerConcurrency; i++) {
+      final int fi = i;
+      dbos.startWorkflow(
+          () -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue("multi_exec_queue"));
+    }
+    impl1.wfSemaphore.acquire(workerConcurrency);
+
+    ConcurrencyTestServiceImpl impl2 = new ConcurrencyTestServiceImpl();
+    try (var dbos2 = new DBOS(dbosConfig.withExecutorId("executor2"))) {
+      dbos2.registerProxy(ConcurrencyTestService.class, impl2);
+      dbos2.launch();
+
+      var qs2 = DBOSTestAccess.getQueueService(dbos2);
+      qs2.setSpeedupForTest();
+      dbos2.registerQueue(
+          "multi_exec_queue",
+          QueueOptions.setWorkerConcurrency(workerConcurrency).andConcurrency(globalConcurrency));
+
+      List<WorkflowHandle<Integer, ?>> handles2 = new ArrayList<>();
+      for (int i = 0; i < workerConcurrency; i++) {
+        final int fi = i;
+        handles2.add(
+            dbos.startWorkflow(
+                () -> service.blockedWorkflow(fi),
+                new StartWorkflowOptions().withQueue("multi_exec_queue")));
+      }
+      impl2.wfSemaphore.acquire(workerConcurrency);
+      for (var h : handles2) {
+        assertEquals("executor2", h.getStatus().executorId());
+      }
+
+      var extra =
+          dbos.startWorkflow(
+              () -> service.noopWorkflow(99),
+              new StartWorkflowOptions().withQueue("multi_exec_queue"));
+      Thread.sleep(2000);
+      assertEquals(WorkflowState.ENQUEUED, extra.getStatus().status());
+
+      impl2.latch.countDown();
+      for (var h : handles2) {
+        h.getResult();
+      }
+      assertEquals(99, (int) extra.getResult());
+    }
+
+    impl1.latch.countDown();
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
   }
 
   private static void awaitCondition(BooleanSupplier condition) throws InterruptedException {

--- a/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
@@ -767,14 +767,13 @@ public class DynamicQueuesTest {
     assertArrayEquals(new String[] {"admin", "operator"}, readBack.authenticatedRoles());
 
     List<String> idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+        systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 0);
 
     assertEquals(2, idsToRun.size());
 
-    // run the same above 2 are in Pending.
+    // 2 are now in Pending; pass localRunningCount=2 to simulate in-memory tracking.
     // So no de queueing
-    idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+    idsToRun = systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 2);
     assertEquals(0, idsToRun.size());
 
     // mark the first 2 as success
@@ -782,15 +781,14 @@ public class DynamicQueuesTest {
         dataSource, WorkflowState.PENDING.name(), WorkflowState.SUCCESS.name());
 
     // next 2 get dequeued
-    idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+    idsToRun = systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 0);
     assertEquals(2, idsToRun.size());
 
     DBUtils.updateAllWorkflowStates(
         dataSource, WorkflowState.PENDING.name(), WorkflowState.SUCCESS.name());
     idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(
-            qwithWCLimit, Constants.DEFAULT_EXECUTORID, Constants.DEFAULT_APP_VERSION, null);
+        systemDatabase.startQueuedWorkflows(
+            qwithWCLimit, Constants.DEFAULT_EXECUTORID, Constants.DEFAULT_APP_VERSION, null, 0);
     assertEquals(0, idsToRun.size());
   }
 
@@ -850,19 +848,20 @@ public class DynamicQueuesTest {
     }
 
     List<String> idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+        systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 0);
     // 0 because global concurrency limit is reached
     assertEquals(0, idsToRun.size());
 
     DBUtils.updateAllWorkflowStates(
         dataSource, WorkflowState.PENDING.name(), WorkflowState.SUCCESS.name());
     idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(
+        systemDatabase.startQueuedWorkflows(
             qwithWCLimit,
             // executorId,
             executor2,
             appVersion,
-            null);
+            null,
+            0);
     assertEquals(2, idsToRun.size());
   }
 

--- a/transact/src/test/java/dev/dbos/transact/queue/QueueChildService.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/QueueChildService.java
@@ -1,0 +1,7 @@
+package dev.dbos.transact.queue;
+
+public interface QueueChildService {
+  String parentWorkflow(String v1, String v2);
+
+  String childWorkflow(String val);
+}

--- a/transact/src/test/java/dev/dbos/transact/queue/QueueChildServiceImpl.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/QueueChildServiceImpl.java
@@ -1,0 +1,74 @@
+package dev.dbos.transact.queue;
+
+import dev.dbos.transact.DBOS;
+import dev.dbos.transact.StartWorkflowOptions;
+import dev.dbos.transact.workflow.Workflow;
+import dev.dbos.transact.workflow.WorkflowHandle;
+import dev.dbos.transact.workflow.WorkflowState;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class QueueChildServiceImpl implements QueueChildService {
+
+  private final DBOS dbos;
+  private QueueChildService self;
+
+  public QueueChildServiceImpl(DBOS dbos) {
+    this.dbos = dbos;
+  }
+
+  public void setSelf(QueueChildService self) {
+    this.self = self;
+  }
+
+  @Override
+  @Workflow
+  public String parentWorkflow(String v1, String v2) {
+    var handles = new ArrayList<WorkflowHandle<String, ?>>();
+    for (var val : new String[] {v1, v2, v1, v2}) {
+      handles.add(
+          dbos.startWorkflow(
+              () -> self.childWorkflow(val), new StartWorkflowOptions().withQueue("child_queue")));
+    }
+
+    // With concurrency=3 and 4 children, the 4th should still be ENQUEUED at this point.
+    var h4 = handles.get(3);
+    dbos.runStep(
+        () -> {
+          var status = dbos.retrieveWorkflow(h4.workflowId()).getStatus();
+          if (status == null || !WorkflowState.ENQUEUED.equals(status.status())) {
+            throw new IllegalStateException(
+                "Expected h4 to be ENQUEUED, got: " + (status == null ? "null" : status.status()));
+          }
+          return null;
+        },
+        "verifyH4Enqueued");
+
+    // Release all children via events.
+    for (var h : handles) {
+      dbos.send(h.workflowId(), "go", "release");
+    }
+
+    var sb = new StringBuilder();
+    for (var h : handles) {
+      try {
+        sb.append(h.getResult());
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return sb.toString();
+  }
+
+  @Override
+  @Workflow
+  public String childWorkflow(String val) {
+    Optional<String> signal = dbos.recv("release", Duration.ofSeconds(30));
+    if (signal.isEmpty()) {
+      throw new RuntimeException("Timed out waiting for release signal");
+    }
+    return val + "d";
+  }
+}

--- a/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
@@ -800,7 +800,7 @@ public class StaticQueuesTest {
     // Start exec2 against the same database; exec1 is full so exec2 picks up new work.
     ConcurrencyTestServiceImpl impl2 = new ConcurrencyTestServiceImpl();
     try (var dbos2 = new DBOS(dbosConfig.withExecutorId("executor2"))) {
-      dbos2.registerProxy(ConcurrencyTestService.class, impl2);
+      ConcurrencyTestService service2 = dbos2.registerProxy(ConcurrencyTestService.class, impl2);
       dbos2.registerQueue(queue);
       dbos2.launch();
 
@@ -808,8 +808,8 @@ public class StaticQueuesTest {
       for (int i = 0; i < workerConcurrency; i++) {
         final int fi = i;
         handles2.add(
-            dbos.startWorkflow(
-                () -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue(queue)));
+            dbos2.startWorkflow(
+                () -> service2.blockedWorkflow(fi), new StartWorkflowOptions().withQueue(queue)));
       }
       impl2.wfSemaphore.acquire(workerConcurrency);
       for (var h : handles2) {
@@ -818,8 +818,8 @@ public class StaticQueuesTest {
 
       // Global limit reached: one more workflow must stay ENQUEUED.
       var extra =
-          dbos.startWorkflow(
-              () -> service.noopWorkflow(99), new StartWorkflowOptions().withQueue(queue));
+          dbos2.startWorkflow(
+              () -> service2.noopWorkflow(99), new StartWorkflowOptions().withQueue(queue));
       Thread.sleep(2000);
       assertEquals(WorkflowState.ENQUEUED, extra.getStatus().status());
 

--- a/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
@@ -463,14 +463,13 @@ public class StaticQueuesTest {
     assertArrayEquals(new String[] {"admin", "operator"}, readBack.authenticatedRoles());
 
     List<String> idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+        systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 0);
 
     assertEquals(2, idsToRun.size());
 
-    // run the same above 2 are in Pending.
+    // 2 are now in Pending; pass localRunningCount=2 to simulate in-memory tracking.
     // So no de queueing
-    idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+    idsToRun = systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 2);
     assertEquals(0, idsToRun.size());
 
     // mark the first 2 as success
@@ -478,15 +477,14 @@ public class StaticQueuesTest {
         dataSource, WorkflowState.PENDING.name(), WorkflowState.SUCCESS.name());
 
     // next 2 get dequeued
-    idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+    idsToRun = systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 0);
     assertEquals(2, idsToRun.size());
 
     DBUtils.updateAllWorkflowStates(
         dataSource, WorkflowState.PENDING.name(), WorkflowState.SUCCESS.name());
     idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(
-            qwithWCLimit, Constants.DEFAULT_EXECUTORID, Constants.DEFAULT_APP_VERSION, null);
+        systemDatabase.startQueuedWorkflows(
+            qwithWCLimit, Constants.DEFAULT_EXECUTORID, Constants.DEFAULT_APP_VERSION, null, 0);
     assertEquals(0, idsToRun.size());
   }
 
@@ -546,19 +544,20 @@ public class StaticQueuesTest {
     }
 
     List<String> idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(qwithWCLimit, executorId, appVersion, null);
+        systemDatabase.startQueuedWorkflows(qwithWCLimit, executorId, appVersion, null, 0);
     // 0 because global concurrency limit is reached
     assertEquals(0, idsToRun.size());
 
     DBUtils.updateAllWorkflowStates(
         dataSource, WorkflowState.PENDING.name(), WorkflowState.SUCCESS.name());
     idsToRun =
-        systemDatabase.getAndStartQueuedWorkflows(
+        systemDatabase.startQueuedWorkflows(
             qwithWCLimit,
             // executorId,
             executor2,
             appVersion,
-            null);
+            null,
+            0);
     assertEquals(2, idsToRun.size());
   }
 

--- a/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
@@ -792,7 +792,8 @@ public class StaticQueuesTest {
     // Fill exec1 to its local workerConcurrency limit.
     for (int i = 0; i < workerConcurrency; i++) {
       final int fi = i;
-      dbos.startWorkflow(() -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue(queue));
+      dbos.startWorkflow(
+          () -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue(queue));
     }
     impl1.wfSemaphore.acquire(workerConcurrency);
 

--- a/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
@@ -28,6 +28,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.*;
@@ -653,6 +654,183 @@ public class StaticQueuesTest {
     assertEquals(2, handle3.getResult());
     assertEquals("local", handle3.getStatus().executorId());
 
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testCancellingQueuedWorkflows() throws Exception {
+    // Cancelling a PENDING workflow should free the concurrency slot so the queued workflow runs.
+    Queue queue = new Queue("test_queue").withConcurrency(1);
+    dbos.registerQueue(queue);
+
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var blockedHandle =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0), new StartWorkflowOptions("blocked").withQueue(queue));
+    var regularHandle =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(42), new StartWorkflowOptions().withQueue(queue));
+
+    impl.wfSemaphore.acquire(1);
+    assertEquals(WorkflowState.PENDING, blockedHandle.getStatus().status());
+    assertEquals(WorkflowState.ENQUEUED, regularHandle.getStatus().status());
+
+    dbos.cancelWorkflow("blocked");
+    assertEquals(WorkflowState.CANCELLED, blockedHandle.getStatus().status());
+    assertEquals(42, (int) regularHandle.getResult());
+
+    impl.latch.countDown(); // let the blocked thread exit cleanly
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testResumingQueuedWorkflows() throws Exception {
+    // Resuming an ENQUEUED workflow bypasses the queue concurrency limit and runs it immediately.
+    Queue queue = new Queue("test_queue").withConcurrency(1);
+    dbos.registerQueue(queue);
+
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var blockedHandle =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0), new StartWorkflowOptions().withQueue(queue));
+    var regularHandle =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(99), new StartWorkflowOptions("resumable").withQueue(queue));
+
+    impl.wfSemaphore.acquire(1);
+    assertEquals(WorkflowState.ENQUEUED, regularHandle.getStatus().status());
+
+    var resumedHandle = dbos.<Integer, Exception>resumeWorkflow("resumable");
+    assertEquals(99, (int) resumedHandle.getResult());
+
+    impl.latch.countDown();
+    blockedHandle.getResult();
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testOneAtATimeWithWorkerConcurrency() throws Exception {
+    // workerConcurrency=1: second workflow must stay ENQUEUED until first completes.
+    Queue queue = new Queue("test_queue").withWorkerConcurrency(1);
+    dbos.registerQueue(queue);
+
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var h1 =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0), new StartWorkflowOptions().withQueue(queue));
+    var h2 =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(1), new StartWorkflowOptions().withQueue(queue));
+
+    impl.wfSemaphore.acquire(1);
+    Thread.sleep(2000); // let several poll cycles run
+    assertEquals(WorkflowState.ENQUEUED, h2.getStatus().status());
+    assertEquals(1, impl.counter.get());
+
+    impl.latch.countDown();
+    assertEquals(0, h1.getResult());
+    assertEquals(1, h2.getResult());
+    assertEquals(1, impl.counter.get());
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testTimeoutQueue() throws Exception {
+    // Workflows with short timeouts should be cancelled; a normal workflow should succeed.
+    Queue queue = new Queue("test_queue").withConcurrency(1);
+    dbos.registerQueue(queue);
+
+    ConcurrencyTestServiceImpl impl = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl);
+    dbos.launch();
+
+    var h1 =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(0),
+            new StartWorkflowOptions().withQueue(queue).withTimeout(500, TimeUnit.MILLISECONDS));
+    var h2 =
+        dbos.startWorkflow(
+            () -> service.blockedWorkflow(1),
+            new StartWorkflowOptions().withQueue(queue).withTimeout(500, TimeUnit.MILLISECONDS));
+    var normalHandle =
+        dbos.startWorkflow(
+            () -> service.noopWorkflow(42),
+            new StartWorkflowOptions().withQueue(queue).withTimeout(10, TimeUnit.SECONDS));
+
+    assertThrows(Exception.class, h1::getResult);
+    assertThrows(Exception.class, h2::getResult);
+    assertEquals(42, (int) normalHandle.getResult());
+    assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
+  }
+
+  @Test
+  public void testMultipleExecutorWorkerConcurrency() throws Exception {
+    // Two DBOS instances share a queue. Each respects workerConcurrency independently;
+    // together they respect the global concurrency cap.
+    int workerConcurrency = 2;
+    int globalConcurrency = workerConcurrency * 2;
+
+    Queue queue =
+        new Queue("multi_exec_queue")
+            .withWorkerConcurrency(workerConcurrency)
+            .withConcurrency(globalConcurrency);
+    dbos.registerQueue(queue);
+
+    ConcurrencyTestServiceImpl impl1 = new ConcurrencyTestServiceImpl();
+    ConcurrencyTestService service = dbos.registerProxy(ConcurrencyTestService.class, impl1);
+    dbos.launch();
+
+    // Fill exec1 to its local workerConcurrency limit.
+    for (int i = 0; i < workerConcurrency; i++) {
+      final int fi = i;
+      dbos.startWorkflow(() -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue(queue));
+    }
+    impl1.wfSemaphore.acquire(workerConcurrency);
+
+    // Start exec2 against the same database; exec1 is full so exec2 picks up new work.
+    ConcurrencyTestServiceImpl impl2 = new ConcurrencyTestServiceImpl();
+    try (var dbos2 = new DBOS(dbosConfig.withExecutorId("executor2"))) {
+      dbos2.registerProxy(ConcurrencyTestService.class, impl2);
+      dbos2.registerQueue(queue);
+      dbos2.launch();
+
+      List<WorkflowHandle<Integer, ?>> handles2 = new ArrayList<>();
+      for (int i = 0; i < workerConcurrency; i++) {
+        final int fi = i;
+        handles2.add(
+            dbos.startWorkflow(
+                () -> service.blockedWorkflow(fi), new StartWorkflowOptions().withQueue(queue)));
+      }
+      impl2.wfSemaphore.acquire(workerConcurrency);
+      for (var h : handles2) {
+        assertEquals("executor2", h.getStatus().executorId());
+      }
+
+      // Global limit reached: one more workflow must stay ENQUEUED.
+      var extra =
+          dbos.startWorkflow(
+              () -> service.noopWorkflow(99), new StartWorkflowOptions().withQueue(queue));
+      Thread.sleep(2000);
+      assertEquals(WorkflowState.ENQUEUED, extra.getStatus().status());
+
+      // Releasing exec2 frees global slots; the extra workflow should now run.
+      impl2.latch.countDown();
+      for (var h : handles2) {
+        h.getResult();
+      }
+      assertEquals(99, (int) extra.getResult());
+    }
+
+    impl1.latch.countDown();
     assertTrue(DBUtils.queueEntriesAreCleanedUp(dataSource));
   }
 


### PR DESCRIPTION
This PR aligns Java queue flow control semantics with the DBOS Python and adds substantial test coverage for queue scenarios.

## Flow control changes 

**Transaction isolation** — REPEATABLE READ is now used only when global flow control is active (`concurrency` or `rateLimit`). Queues using only `workerConcurrency` use READ COMMITTED.

**Rate limit query** — The limiter SELECT now filters `AND rate_limited = true`, matching the partial index on that column. Without this, the limiter query was doing a full scan and missing the index entirely.

**Worker concurrency** — Local worker concurrency no longer issues a DB round-trip. Instead it reads an in-memory count from `DBOSExecutor`

**Global concurrency** — The COUNT query no longer groups by `executor_id`. 

**Dequeue UPDATE** — The UPDATE now includes `AND status = 'ENQUEUED'` as a safety guard, matching Python's `if update_res.rowcount > 0` check. If another worker claimed the row between SELECT and UPDATE, the affected-row count will be 0 and the workflow is excluded from the returned list.

**ORDER BY** — All dequeue SELECTs now unconditionally sort by `priority ASC, created_at ASC`, 

**No early exit on `maxTasks = 0`** — The early-return guard was removed; a zero-limit SELECT is issued and returns no rows naturally, matching Python's behavior.

## In-memory workflow tracking (`DBOSExecutor.java`)

renamed `workflowsInProgress` to `activeWorkflows` and it maps to a `QueueBucket` instance. Workflow ownership claim and queue-bucket registration happen in a single atomic `putIfAbsent`. The queueBuckets for `activeWorkflows` are used to get counts of local queue execution 

## New tests

**`SystemDatabaseTest`** — Three isolation-level tests verify that `workerConcurrency`-only queues use READ COMMITTED and that `concurrency`/`rateLimit` queues use REPEATABLE READ. 

**`StaticQueuesTest` and `DynamicQueuesTest`** — Seven new tests added to both suites:
- `testCancellingQueuedWorkflows` — cancelling a PENDING workflow frees the concurrency slot
- `testResumingQueuedWorkflows` — `resumeWorkflow` bypasses queue concurrency limits
- `testOneAtATimeWithWorkerConcurrency` — `workerConcurrency=1` blocks dequeue until the running workflow completes, verified against the in-memory counter
- `testTimeoutQueue` — workflows with short timeouts are cancelled; a normally-timed workflow succeeds
- `testMultipleExecutorWorkerConcurrency` — two in-process DBOS instances share a queue; each independently enforces `workerConcurrency` while both respect the global cap
- `testQueueChildWorkflow` — a workflow enqueues child workflows on a bounded queue using `dbos.startWorkflow` + `dbos.send`/`recv`; verifies the 4th child blocks until a slot opens
- `testQueueDeduplication` — verifies dedup ID collision throws `DBOSQueueDuplicatedException`, re-enqueue with the same workflow ID is idempotent, and the dedup ID is releasable after completion

fixes #412