### PR TITLE
Eliminate ASM dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-asm = "9.10.1"
 aspectj = "1.9.25.1"
 assertj = "3.27.7"
 cron-utils = "9.2.1"
@@ -39,7 +38,6 @@ testcontainers = "2.0.5"
 versions = "0.54.0"
 
 [libraries]
-asm = { module = "org.ow2.asm:asm", version.ref = "asm" }
 aspectjweaver = { module = "org.aspectj:aspectjweaver", version.ref = "aspectj" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 cron-utils = { module = "com.cronutils:cron-utils", version.ref = "cron-utils" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,9 +79,6 @@ system-stubs-jupiter = { module = "uk.org.webcompere:system-stubs-jupiter", vers
 testcontainers-cockroachdb = { module = "org.testcontainers:testcontainers-cockroachdb", version.ref = "testcontainers" }
 testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql", version.ref = "testcontainers" }
 
-[bundles]
-jackson = ["jackson-databind"]
-
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "maven-publish" }

--- a/transact-cli/build.gradle.kts
+++ b/transact-cli/build.gradle.kts
@@ -7,7 +7,7 @@ application { mainClass.set("dev.dbos.transact.cli.Main") }
 
 dependencies {
   implementation(project(":transact"))
-  implementation(libs.bundles.jackson)
+  implementation(libs.jackson.databind)
   implementation(libs.picocli)
   runtimeOnly(libs.slf4j.simple)
 

--- a/transact-spring-boot-starter/build.gradle.kts
+++ b/transact-spring-boot-starter/build.gradle.kts
@@ -12,6 +12,7 @@ mavenPublishing {
 
 dependencies {
   api(project(":transact"))
+  implementation(libs.slf4j.api)
   compileOnly(libs.spring.boot.autoconfigure)
   compileOnly(libs.spring.aop)
   compileOnly(libs.aspectjweaver)

--- a/transact-spring-txstep-starter/build.gradle.kts
+++ b/transact-spring-txstep-starter/build.gradle.kts
@@ -12,6 +12,7 @@ mavenPublishing {
 
 dependencies {
   api(project(":transact"))
+  implementation(libs.slf4j.api)
   compileOnly(project(":transact-spring-boot-starter"))
   compileOnly(libs.spring.boot.autoconfigure)
   compileOnly(libs.spring.aop)

--- a/transact/build.gradle.kts
+++ b/transact/build.gradle.kts
@@ -8,13 +8,13 @@ plugins {
 }
 
 dependencies {
-  api(libs.slf4j.api)
   api(libs.jspecify)
 
-  implementation(libs.postgresql)
-  implementation(libs.hikaricp)
-  implementation(libs.bundles.jackson)
   implementation(libs.cron.utils)
+  implementation(libs.hikaricp)
+  implementation(libs.jackson.databind)
+  implementation(libs.postgresql)
+  implementation(libs.slf4j.api)
 
   testImplementation(platform(libs.junit.bom))
   testImplementation(libs.junit.jupiter)

--- a/transact/build.gradle.kts
+++ b/transact/build.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
   api(libs.slf4j.api)
   api(libs.jspecify)
 
-  implementation(libs.asm)
   implementation(libs.postgresql)
   implementation(libs.hikaricp)
   implementation(libs.bundles.jackson)

--- a/transact/src/main/java/dev/dbos/transact/internal/AppVersionComputer.java
+++ b/transact/src/main/java/dev/dbos/transact/internal/AppVersionComputer.java
@@ -24,76 +24,84 @@ public class AppVersionComputer {
       final var hasher = MessageDigest.getInstance("SHA-256");
       hasher.update(dbosVersion.getBytes(StandardCharsets.UTF_8));
 
-      var sortedWorkflows =
+      var workflowIterator =
           workflows.stream()
               .sorted(Comparator.comparing(RegisteredWorkflow::fullyQualifiedName))
               .iterator();
 
-      while (sortedWorkflows.hasNext()) {
-        var wf = sortedWorkflows.next();
+      while (workflowIterator.hasNext()) {
+        var wf = workflowIterator.next();
         var klass = wf.workflowMethod().getDeclaringClass();
         var klassPath = klass.getName().replace('.', '/') + ".class";
         var methodDesc = getMethodDescriptor(wf.workflowMethod());
 
         hasher.update(wf.fullyQualifiedName().getBytes(StandardCharsets.UTF_8));
         hasher.update(methodDesc.getBytes(StandardCharsets.UTF_8));
-        try (var in = klass.getClassLoader().getResourceAsStream(klassPath)) {
+        var cl = klass.getClassLoader();
+        if (cl == null) cl = ClassLoader.getSystemClassLoader();
+        try (var in = cl.getResourceAsStream(klassPath)) {
           if (in == null) throw new IOException("%s class not found".formatted(klass.getName()));
           hashMethodBytecode(hasher, in, wf.workflowMethod().getName(), methodDesc);
         }
       }
 
       return HexFormat.of().formatHex(hasher.digest());
-    } catch (Throwable e) {
+    } catch (Exception e) {
       logger.warn("Failed to compute app version", e);
       return "unknown-" + System.currentTimeMillis();
     }
   }
 
   /**
-   * Manually parses the JVM class file format (JVMS Chapter 4) to locate the method matching {@code
-   * methodName/methodDesc}, then hashes the raw bytecode and exception table from its Code
-   * attribute.
+   * Manually parses the JVM class file format (JVMS 4.1, 4.4, 4.5, 4.6, 4.7) to locate the method
+   * matching {@code methodName/methodDesc}, then hashes the raw bytecodes and exception table from
+   * its Code attribute (JVMS 4.7.3).
+   *
+   * <p>Only CONSTANT_Utf8 entries are decoded from the constant pool — all other entry types are
+   * skipped by size, since we only need string values to match method names and descriptors.
+   *
+   * <p>Once the matching Code attribute is found, the code[] bytes and exception_table are fed into
+   * the SHA-256 digest. The method stops early — remaining methods and attributes after the target
+   * are not parsed.
    */
   private static void hashMethodBytecode(
       MessageDigest hasher, InputStream in, String methodName, String methodDesc) {
     try {
       var data = new DataInputStream(in);
 
+      // --- ClassFile header (JVMS 4.1) ---
       if (data.readInt() != 0xCAFEBABE) {
         throw new IOException("Invalid class file: bad magic number");
       }
-
       data.readUnsignedShort(); // minor_version
       data.readUnsignedShort(); // major_version
 
+      // --- Constant pool (JVMS 4.4) ---
+      // Indices start at 1; entry 0 is reserved and not stored.
       int cpCount = data.readUnsignedShort();
       var utf8Pool = new String[cpCount];
 
       for (int i = 1; i < cpCount; i++) {
         int tag = data.readUnsignedByte();
         switch (tag) {
-          case 1: // CONSTANT_Utf8
-            int len = data.readUnsignedShort();
-            byte[] bytes = new byte[len];
-            data.readFully(bytes);
-            utf8Pool[i] = new String(bytes, StandardCharsets.UTF_8);
+          case 1: // CONSTANT_Utf8 (JVMS 4.4.7) — stored in modified UTF-8
+            utf8Pool[i] = data.readUTF();
             break;
           case 3: // CONSTANT_Integer
           case 4: // CONSTANT_Float
-            data.skipBytes(4);
+            data.skipNBytes(4);
             break;
           case 5: // CONSTANT_Long
           case 6: // CONSTANT_Double
-            data.skipBytes(8);
-            i++; // Long and Double occupy two constant pool slots
+            data.skipNBytes(8);
+            i++; // Long and Double occupy two consecutive constant pool slots
             break;
           case 7: // CONSTANT_Class
           case 8: // CONSTANT_String
           case 16: // CONSTANT_MethodType
           case 19: // CONSTANT_Module
           case 20: // CONSTANT_Package
-            data.skipBytes(2);
+            data.skipNBytes(2);
             break;
           case 9: // CONSTANT_Fieldref
           case 10: // CONSTANT_Methodref
@@ -101,78 +109,92 @@ public class AppVersionComputer {
           case 12: // CONSTANT_NameAndType
           case 17: // CONSTANT_Dynamic
           case 18: // CONSTANT_InvokeDynamic
-            data.skipBytes(4);
+            data.skipNBytes(4);
             break;
           case 15: // CONSTANT_MethodHandle
-            data.skipBytes(3);
+            data.skipNBytes(3);
             break;
           default:
             throw new IOException("Unknown constant pool tag: " + tag);
         }
       }
 
+      // --- Class header fields (JVMS 4.1) ---
       data.readUnsignedShort(); // access_flags
       data.readUnsignedShort(); // this_class
       data.readUnsignedShort(); // super_class
 
+      // --- Interfaces (JVMS 4.1) ---
       int ifCount = data.readUnsignedShort();
-      data.skipBytes(ifCount * 2);
+      data.skipNBytes(ifCount * 2L); // each entry is a u2 constant pool index
 
+      // --- Fields (JVMS 4.5) — skip entirely ---
       int fieldCount = data.readUnsignedShort();
       for (int i = 0; i < fieldCount; i++) {
-        data.skipBytes(6); // access_flags + name_index + descriptor_index
+        data.skipNBytes(6); // access_flags + name_index + descriptor_index
         int attrCount = data.readUnsignedShort();
         for (int j = 0; j < attrCount; j++) {
-          data.skipBytes(2); // attribute_name_index
-          data.skipBytes(data.readInt()); // attribute_length
+          data.skipNBytes(2); // attribute_name_index
+          data.skipNBytes(Integer.toUnsignedLong(data.readInt())); // attribute_length (u4)
         }
       }
 
+      // --- Methods (JVMS 4.6) ---
       int methodCount = data.readUnsignedShort();
       boolean found = false;
-      for (int i = 0; i < methodCount; i++) {
+      for (int i = 0; i < methodCount && !found; i++) {
         data.readUnsignedShort(); // access_flags
         int nameIndex = data.readUnsignedShort();
         int descIndex = data.readUnsignedShort();
         int attrCount = data.readUnsignedShort();
 
+        // Resolve method name and descriptor from the constant pool.
         String name = nameIndex < cpCount ? utf8Pool[nameIndex] : null;
         String desc = descIndex < cpCount ? utf8Pool[descIndex] : null;
         boolean isTarget = methodName.equals(name) && methodDesc.equals(desc);
 
         for (int j = 0; j < attrCount; j++) {
           int attrNameIndex = data.readUnsignedShort();
-          int attrLen = data.readInt();
+          long attrLen = Integer.toUnsignedLong(data.readInt()); // attribute_length (u4)
 
-          if (isTarget && !found) {
+          if (isTarget) {
             String attrName = attrNameIndex < cpCount ? utf8Pool[attrNameIndex] : null;
             if ("Code".equals(attrName)) {
 
-              data.skipBytes(4); // max_stack + max_locals
+              // --- Code attribute (JVMS 4.7.3) ---
+              // Contains the actual JVM bytecodes and exception table for the method body.
+              data.skipNBytes(4); // max_stack (u2) + max_locals (u2)
+
+              // code[] — the raw JVM instruction stream.
               int codeLen = data.readInt();
+              if (codeLen < 0) throw new IOException("code_length exceeds maximum supported size");
               byte[] code = new byte[codeLen];
               data.readFully(code);
               hasher.update(code);
 
+              // exception_table — structured try-catch entries.
+              // Each entry is 8 bytes: start_pc (u2) + end_pc (u2) + handler_pc (u2) + catch_type
+              // (u2).
               int excLen = data.readUnsignedShort();
               for (int k = 0; k < excLen; k++) {
-                byte[] entry = new byte[8]; // start_pc + end_pc + handler_pc + catch_type
+                byte[] entry = new byte[8];
                 data.readFully(entry);
                 hasher.update(entry);
               }
 
+              // Skip sub-attributes (LineNumberTable, LocalVariableTable, etc.).
               int codeAttrCount = data.readUnsignedShort();
               for (int k = 0; k < codeAttrCount; k++) {
-                data.skipBytes(2); // attribute_name_index
-                data.skipBytes(data.readInt()); // attribute_length
+                data.skipNBytes(2); // attribute_name_index
+                data.skipNBytes(Integer.toUnsignedLong(data.readInt())); // attribute_length (u4)
               }
 
               found = true;
             } else {
-              data.skipBytes(attrLen);
+              data.skipNBytes(attrLen);
             }
           } else {
-            data.skipBytes(attrLen);
+            data.skipNBytes(attrLen);
           }
         }
       }

--- a/transact/src/main/java/dev/dbos/transact/internal/AppVersionComputer.java
+++ b/transact/src/main/java/dev/dbos/transact/internal/AppVersionComputer.java
@@ -2,19 +2,15 @@ package dev.dbos.transact.internal;
 
 import dev.dbos.transact.execution.RegisteredWorkflow;
 
+import java.io.DataInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Handle;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,175 +25,192 @@ public class AppVersionComputer {
       hasher.update(dbosVersion.getBytes(StandardCharsets.UTF_8));
 
       var sortedWorkflows =
-          workflows.stream().sorted(Comparator.comparing(RegisteredWorkflow::fullyQualifiedName));
-      var it = sortedWorkflows.iterator();
+          workflows.stream()
+              .sorted(Comparator.comparing(RegisteredWorkflow::fullyQualifiedName))
+              .iterator();
 
-      while (it.hasNext()) {
-        var wf = it.next();
-        hasher.update(wf.fullyQualifiedName().getBytes(StandardCharsets.UTF_8));
-
+      while (sortedWorkflows.hasNext()) {
+        var wf = sortedWorkflows.next();
         var klass = wf.workflowMethod().getDeclaringClass();
         var klassPath = klass.getName().replace('.', '/') + ".class";
-        var methodDesc = Type.getMethodDescriptor(wf.workflowMethod());
-        var methodName = wf.workflowMethod().getName();
+        var methodDesc = getMethodDescriptor(wf.workflowMethod());
 
+        hasher.update(wf.fullyQualifiedName().getBytes(StandardCharsets.UTF_8));
+        hasher.update(methodDesc.getBytes(StandardCharsets.UTF_8));
         try (var in = klass.getClassLoader().getResourceAsStream(klassPath)) {
           if (in == null) throw new IOException("%s class not found".formatted(klass.getName()));
-          var reader = new ClassReader(in);
-          reader.accept(
-              new ClassVisitor(Opcodes.ASM9) {
-                @Override
-                public MethodVisitor visitMethod(
-                    int access, String name, String desc, String signature, String[] exceptions) {
-                  return (name.equals(methodName) && desc.equals(methodDesc))
-                      ? new HashingMethodVisitor(hasher)
-                      : null;
-                }
-              },
-              0);
+          hashMethodBytecode(hasher, in, wf.workflowMethod().getName(), methodDesc);
         }
       }
 
-      return bytesToHex(hasher.digest());
-    } catch (NoSuchAlgorithmException | IOException e) {
+      return HexFormat.of().formatHex(hasher.digest());
+    } catch (Throwable e) {
       logger.warn("Failed to compute app version", e);
       return "unknown-" + System.currentTimeMillis();
     }
   }
 
-  static class HashingMethodVisitor extends MethodVisitor {
-    private final MessageDigest md;
-    private final Map<Label, Integer> labelOrdinals = new LinkedHashMap<>();
-    private int nextLabelOrdinal = 0;
+  /**
+   * Manually parses the JVM class file format (JVMS Chapter 4) to locate the method matching {@code
+   * methodName/methodDesc}, then hashes the raw bytecode and exception table from its Code
+   * attribute.
+   */
+  private static void hashMethodBytecode(
+      MessageDigest hasher, InputStream in, String methodName, String methodDesc) {
+    try {
+      var data = new DataInputStream(in);
 
-    public HashingMethodVisitor(MessageDigest md) {
-      super(Opcodes.ASM9);
-      this.md = md;
-    }
-
-    private int labelOrdinal(Label label) {
-      return labelOrdinals.computeIfAbsent(label, l -> nextLabelOrdinal++);
-    }
-
-    private void update(String... values) {
-      for (var v : values) {
-        if (v != null) md.update(v.getBytes(StandardCharsets.UTF_8));
+      if (data.readInt() != 0xCAFEBABE) {
+        throw new IOException("Invalid class file: bad magic number");
       }
-    }
 
-    private void update(int... values) {
-      for (var v : values) {
-        md.update((byte) (v >>> 24));
-        md.update((byte) (v >>> 16));
-        md.update((byte) (v >>> 8));
-        md.update((byte) v);
+      data.readUnsignedShort(); // minor_version
+      data.readUnsignedShort(); // major_version
+
+      int cpCount = data.readUnsignedShort();
+      var utf8Pool = new String[cpCount];
+
+      for (int i = 1; i < cpCount; i++) {
+        int tag = data.readUnsignedByte();
+        switch (tag) {
+          case 1: // CONSTANT_Utf8
+            int len = data.readUnsignedShort();
+            byte[] bytes = new byte[len];
+            data.readFully(bytes);
+            utf8Pool[i] = new String(bytes, StandardCharsets.UTF_8);
+            break;
+          case 3: // CONSTANT_Integer
+          case 4: // CONSTANT_Float
+            data.skipBytes(4);
+            break;
+          case 5: // CONSTANT_Long
+          case 6: // CONSTANT_Double
+            data.skipBytes(8);
+            i++; // Long and Double occupy two constant pool slots
+            break;
+          case 7: // CONSTANT_Class
+          case 8: // CONSTANT_String
+          case 16: // CONSTANT_MethodType
+          case 19: // CONSTANT_Module
+          case 20: // CONSTANT_Package
+            data.skipBytes(2);
+            break;
+          case 9: // CONSTANT_Fieldref
+          case 10: // CONSTANT_Methodref
+          case 11: // CONSTANT_InterfaceMethodref
+          case 12: // CONSTANT_NameAndType
+          case 17: // CONSTANT_Dynamic
+          case 18: // CONSTANT_InvokeDynamic
+            data.skipBytes(4);
+            break;
+          case 15: // CONSTANT_MethodHandle
+            data.skipBytes(3);
+            break;
+          default:
+            throw new IOException("Unknown constant pool tag: " + tag);
+        }
       }
-    }
 
-    @Override
-    public void visitLabel(Label label) {
-      labelOrdinal(label);
-    }
+      data.readUnsignedShort(); // access_flags
+      data.readUnsignedShort(); // this_class
+      data.readUnsignedShort(); // super_class
 
-    @Override
-    public void visitInsn(int opcode) {
-      update(opcode);
-    }
+      int ifCount = data.readUnsignedShort();
+      data.skipBytes(ifCount * 2);
 
-    @Override
-    public void visitIntInsn(int opcode, int operand) {
-      update(opcode, operand);
-    }
-
-    @Override
-    public void visitVarInsn(int opcode, int varIndex) {
-      update(opcode, varIndex);
-    }
-
-    @Override
-    public void visitTypeInsn(int opcode, String type) {
-      update(opcode);
-      update(type);
-    }
-
-    @Override
-    public void visitFieldInsn(int opcode, String owner, String name, String descriptor) {
-      update(opcode);
-      update(owner, name, descriptor);
-    }
-
-    @Override
-    public void visitMethodInsn(
-        int opcode, String owner, String name, String descriptor, boolean isInterface) {
-      update(opcode);
-      update(owner, name, descriptor);
-      update(isInterface ? 1 : 0);
-    }
-
-    @Override
-    public void visitInvokeDynamicInsn(
-        String name,
-        String descriptor,
-        Handle bootstrapMethodHandle,
-        Object... bootstrapMethodArguments) {
-      update(name, descriptor);
-      update(bootstrapMethodHandle.toString());
-      for (var arg : bootstrapMethodArguments) {
-        if (arg != null) update(arg.toString());
+      int fieldCount = data.readUnsignedShort();
+      for (int i = 0; i < fieldCount; i++) {
+        data.skipBytes(6); // access_flags + name_index + descriptor_index
+        int attrCount = data.readUnsignedShort();
+        for (int j = 0; j < attrCount; j++) {
+          data.skipBytes(2); // attribute_name_index
+          data.skipBytes(data.readInt()); // attribute_length
+        }
       }
-    }
 
-    @Override
-    public void visitJumpInsn(int opcode, Label label) {
-      update(opcode, labelOrdinal(label));
-    }
+      int methodCount = data.readUnsignedShort();
+      boolean found = false;
+      for (int i = 0; i < methodCount; i++) {
+        data.readUnsignedShort(); // access_flags
+        int nameIndex = data.readUnsignedShort();
+        int descIndex = data.readUnsignedShort();
+        int attrCount = data.readUnsignedShort();
 
-    @Override
-    public void visitLdcInsn(Object value) {
-      update(Opcodes.LDC);
-      if (value != null) update(value.toString());
-    }
+        String name = nameIndex < cpCount ? utf8Pool[nameIndex] : null;
+        String desc = descIndex < cpCount ? utf8Pool[descIndex] : null;
+        boolean isTarget = methodName.equals(name) && methodDesc.equals(desc);
 
-    @Override
-    public void visitIincInsn(int varIndex, int increment) {
-      update(Opcodes.IINC, varIndex, increment);
-    }
+        for (int j = 0; j < attrCount; j++) {
+          int attrNameIndex = data.readUnsignedShort();
+          int attrLen = data.readInt();
 
-    @Override
-    public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
-      update(Opcodes.TABLESWITCH, min, max, labelOrdinal(dflt));
-      for (var l : labels) update(labelOrdinal(l));
-    }
+          if (isTarget && !found) {
+            String attrName = attrNameIndex < cpCount ? utf8Pool[attrNameIndex] : null;
+            if ("Code".equals(attrName)) {
 
-    @Override
-    public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
-      update(Opcodes.LOOKUPSWITCH, labelOrdinal(dflt));
-      update(keys);
-      for (var l : labels) update(labelOrdinal(l));
-    }
+              data.skipBytes(4); // max_stack + max_locals
+              int codeLen = data.readInt();
+              byte[] code = new byte[codeLen];
+              data.readFully(code);
+              hasher.update(code);
 
-    @Override
-    public void visitMultiANewArrayInsn(String descriptor, int numDimensions) {
-      update(Opcodes.MULTIANEWARRAY, numDimensions);
-      update(descriptor);
-    }
+              int excLen = data.readUnsignedShort();
+              for (int k = 0; k < excLen; k++) {
+                byte[] entry = new byte[8]; // start_pc + end_pc + handler_pc + catch_type
+                data.readFully(entry);
+                hasher.update(entry);
+              }
 
-    @Override
-    public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
-      update(labelOrdinal(start), labelOrdinal(end), labelOrdinal(handler));
-      update(type);
+              int codeAttrCount = data.readUnsignedShort();
+              for (int k = 0; k < codeAttrCount; k++) {
+                data.skipBytes(2); // attribute_name_index
+                data.skipBytes(data.readInt()); // attribute_length
+              }
+
+              found = true;
+            } else {
+              data.skipBytes(attrLen);
+            }
+          } else {
+            data.skipBytes(attrLen);
+          }
+        }
+      }
+
+      if (!found) {
+        throw new IOException(
+            "Method %s%s not found in class file".formatted(methodName, methodDesc));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to hash method bytecode", e);
     }
   }
 
-  private static String bytesToHex(byte[] bytes) {
-    StringBuilder hexString = new StringBuilder();
-    for (byte b : bytes) {
-      String hex = Integer.toHexString(0xff & b);
-      if (hex.length() == 1) {
-        hexString.append('0');
-      }
-      hexString.append(hex);
+  private static String getMethodDescriptor(Method method) {
+    var sb = new StringBuilder("(");
+    for (var param : method.getParameterTypes()) {
+      sb.append(getTypeDescriptor(param));
     }
-    return hexString.toString();
+    sb.append(")");
+    sb.append(getTypeDescriptor(method.getReturnType()));
+    return sb.toString();
+  }
+
+  private static String getTypeDescriptor(Class<?> type) {
+    if (type.isPrimitive()) {
+      if (type == void.class) return "V";
+      if (type == int.class) return "I";
+      if (type == long.class) return "J";
+      if (type == byte.class) return "B";
+      if (type == short.class) return "S";
+      if (type == char.class) return "C";
+      if (type == float.class) return "F";
+      if (type == double.class) return "D";
+      if (type == boolean.class) return "Z";
+    }
+    if (type.isArray()) {
+      return "[" + getTypeDescriptor(type.getComponentType());
+    }
+    return "L" + type.getName().replace('.', '/') + ";";
   }
 }


### PR DESCRIPTION
ASM is a powerful byte code manipulation library. We were only using it to parse class files when hashing registered workflow methods for a generated an app version. This PR manually writes that class parsing file so we can drop the ASM dependency 

fixes #422