### PR TITLE
Tx Step isolation and retry

### DIFF
--- a/transact-jdbi-step-factory/src/main/java/dev/dbos/transact/jdbi/JdbiStepFactory.java
+++ b/transact-jdbi-step-factory/src/main/java/dev/dbos/transact/jdbi/JdbiStepFactory.java
@@ -108,27 +108,50 @@ public class JdbiStepFactory extends PostgresStepFactory {
    */
   public <R, X extends Exception> R inStep(final HandleCallback<R, X> callback, String stepName)
       throws X {
+    return inStep(callback, new JdbiStepOptions(stepName));
+  }
+
+  /**
+   * Executes {@code callback} as an idempotent DBOS step inside a Jdbi transaction.
+   *
+   * <p>Behaves identically to {@link #inStep(HandleCallback, String)} but accepts a {@link
+   * JdbiStepOptions} to control the step name and transaction isolation level.
+   *
+   * @param <R> the return type of the callback
+   * @param <X> the checked exception type the callback may throw
+   * @param callback the database work to perform; receives an open {@link Handle} and must not
+   *     commit or close it
+   * @param options step name and optional isolation level override
+   * @return the value returned by {@code callback}
+   * @throws X if the callback throws
+   */
+  public <R, X extends Exception> R inStep(
+      final HandleCallback<R, X> callback, JdbiStepOptions options) throws X {
+    var jdbiLevel = options.isolationLevel();
     return runTxStep(
         (wfId, stepId) -> {
+          HandleCallback<R, X> wrapped =
+              h -> {
+                var result = callback.withHandle(h);
+                recordOutput(h, wfId, stepId, result);
+                return result;
+              };
           try {
-            return jdbi.inTransaction(
-                h -> {
-                  var result = callback.withHandle(h);
-                  recordOutput(h, wfId, stepId, result);
-                  return result;
-                });
+            return jdbiLevel != null
+                ? jdbi.inTransaction(jdbiLevel, wrapped)
+                : jdbi.inTransaction(wrapped);
           } catch (StepConflictException e) {
-            return checkExecution(wfId, stepId, stepName)
+            return checkExecution(wfId, stepId, options.name())
                 .orElseThrow(
                     () ->
                         new IllegalStateException(
                             "Conflict on tx_step_outputs but winner row not found: workflowId=%s stepId=%d stepName=%s"
-                                .formatted(wfId, stepId, stepName),
+                                .formatted(wfId, stepId, options.name()),
                             e))
                 .<R, X>toResult(serializer);
           }
         },
-        stepName);
+        options.name());
   }
 
   /**
@@ -146,12 +169,30 @@ public class JdbiStepFactory extends PostgresStepFactory {
    */
   public <X extends Exception> void useStep(final HandleConsumer<X> callback, String stepName)
       throws X {
+    useStep(callback, new JdbiStepOptions(stepName));
+  }
+
+  /**
+   * Executes {@code callback} as an idempotent DBOS step inside a Jdbi transaction, with no return
+   * value.
+   *
+   * <p>Behaves identically to {@link #inStep(HandleCallback, JdbiStepOptions)} but accepts a {@link
+   * HandleConsumer} for callers that do not need to return a result.
+   *
+   * @param <X> the checked exception type the callback may throw
+   * @param callback the database work to perform; receives an open {@link Handle} and must not
+   *     commit or close it
+   * @param options step name and optional isolation level override
+   * @throws X if the callback throws
+   */
+  public <X extends Exception> void useStep(
+      final HandleConsumer<X> callback, JdbiStepOptions options) throws X {
     inStep(
         handle -> {
           callback.useHandle(handle);
           return null;
         },
-        stepName);
+        options);
   }
 
   @Override

--- a/transact-jdbi-step-factory/src/main/java/dev/dbos/transact/jdbi/JdbiStepOptions.java
+++ b/transact-jdbi-step-factory/src/main/java/dev/dbos/transact/jdbi/JdbiStepOptions.java
@@ -1,0 +1,18 @@
+package dev.dbos.transact.jdbi;
+
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
+
+/**
+ * Options for a transactional step executed via {@link JdbiStepFactory}.
+ *
+ * @param name the stable step name used for idempotency tracking within the workflow
+ * @param isolationLevel the transaction isolation level to request; {@code null} leaves the
+ *     connection's level unchanged
+ */
+public record JdbiStepOptions(String name, TransactionIsolationLevel isolationLevel) {
+
+  /** Creates options with no isolation level override. */
+  public JdbiStepOptions(String name) {
+    this(name, null);
+  }
+}

--- a/transact-jdbi-step-factory/src/test/java/dev/dbos/transact/jdbi/JdbiStepFactoryTest.java
+++ b/transact-jdbi-step-factory/src/test/java/dev/dbos/transact/jdbi/JdbiStepFactoryTest.java
@@ -18,6 +18,7 @@ import dev.dbos.transact.workflow.WorkflowHandle;
 
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
@@ -40,6 +41,8 @@ interface FactoryTestService {
   TestResult insertThenReadWorkflow(String user);
 
   TestResult conflictWorkflow(String user) throws SQLException;
+
+  TestResult serializationRetryWorkflow(String user);
 }
 
 class FactoryTestServiceImpl implements FactoryTestService {
@@ -47,6 +50,8 @@ class FactoryTestServiceImpl implements FactoryTestService {
   private final JdbiStepFactory stepFactory;
   private final DataSource dataSource;
   final String schema;
+
+  final AtomicInteger retryAttempts = new AtomicInteger();
 
   public FactoryTestServiceImpl(JdbiStepFactory stepFactory, DataSource dataSource, String schema) {
     this.stepFactory = stepFactory;
@@ -114,6 +119,20 @@ class FactoryTestServiceImpl implements FactoryTestService {
   public FactoryTestService.TestResult insertThenReadWorkflow(String user) {
     stepFactory.useStep((Handle h) -> insertGreeting(h, user), "insertGreeting");
     return stepFactory.inStep((Handle h) -> readGreeting(h, user), "readGreeting");
+  }
+
+  @Override
+  @Workflow
+  public FactoryTestService.TestResult serializationRetryWorkflow(String user) {
+    return stepFactory.inStep(
+        (Handle h) -> {
+          if (retryAttempts.incrementAndGet() <= 2) {
+            throw new RuntimeException(
+                new SQLException("simulated serialization failure", "40001"));
+          }
+          return insertGreeting(h, user);
+        },
+        "serializationRetry");
   }
 
   // Simulates a concurrent winner committing a result while this executor's transaction is still
@@ -444,6 +463,25 @@ public class JdbiStepFactoryTest {
     assertNull(row.error());
     var output = SerializationUtil.deserializeValue(row.output(), row.serialization(), null);
     assertEquals(new FactoryTestService.TestResult(user, 99), output);
+  }
+
+  @Test
+  public void testSerializationRetry() throws Exception {
+    var wfid = "wf-ser-retry";
+    var user = "retryUser";
+
+    try (var _o = new WorkflowOptions(wfid).setContext()) {
+      var result = proxy.serializationRetryWorkflow(user);
+      assertEquals(1, result.greetCount());
+      assertEquals(user, result.user());
+    }
+
+    assertEquals(3, impl.retryAttempts.get()); // 2 failures + 1 success
+    assertEquals(1, getGreetCount(user));
+    var rows = DBUtils.getTxStepRows(dataSource, wfid);
+    assertEquals(1, rows.size());
+    assertNotNull(rows.get(0).output());
+    assertNull(rows.get(0).error());
   }
 
   @Test

--- a/transact-jdbi-step-factory/src/test/java/dev/dbos/transact/jdbi/JdbiStepFactoryTest.java
+++ b/transact-jdbi-step-factory/src/test/java/dev/dbos/transact/jdbi/JdbiStepFactoryTest.java
@@ -25,6 +25,7 @@ import javax.sql.DataSource;
 import com.zaxxer.hikari.HikariDataSource;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.transaction.TransactionIsolationLevel;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,8 @@ interface FactoryTestService {
   TestResult conflictWorkflow(String user) throws SQLException;
 
   TestResult serializationRetryWorkflow(String user);
+
+  String isolationLevelWorkflow(TransactionIsolationLevel level);
 }
 
 class FactoryTestServiceImpl implements FactoryTestService {
@@ -133,6 +136,18 @@ class FactoryTestServiceImpl implements FactoryTestService {
           return insertGreeting(h, user);
         },
         "serializationRetry");
+  }
+
+  @Override
+  @Workflow
+  public String isolationLevelWorkflow(TransactionIsolationLevel level) {
+    return stepFactory.inStep(
+        h ->
+            h.createQuery("SELECT current_setting('transaction_isolation')")
+                .mapTo(String.class)
+                .findFirst()
+                .orElseThrow(),
+        new JdbiStepOptions("checkIsolation", level));
   }
 
   // Simulates a concurrent winner committing a result while this executor's transaction is still
@@ -482,6 +497,23 @@ public class JdbiStepFactoryTest {
     assertEquals(1, rows.size());
     assertNotNull(rows.get(0).output());
     assertNull(rows.get(0).error());
+  }
+
+  @Test
+  public void testIsolationLevel() throws Exception {
+    try (var _o = new WorkflowOptions("wf-iso-ser").setContext()) {
+      assertEquals(
+          "serializable", proxy.isolationLevelWorkflow(TransactionIsolationLevel.SERIALIZABLE));
+    }
+    try (var _o = new WorkflowOptions("wf-iso-rc").setContext()) {
+      assertEquals(
+          "read committed", proxy.isolationLevelWorkflow(TransactionIsolationLevel.READ_COMMITTED));
+    }
+    try (var _o = new WorkflowOptions("wf-iso-rr").setContext()) {
+      assertEquals(
+          "repeatable read",
+          proxy.isolationLevelWorkflow(TransactionIsolationLevel.REPEATABLE_READ));
+    }
   }
 
   @Test

--- a/transact-jooq-step-factory/src/main/java/dev/dbos/transact/jooq/JooqStepFactory.java
+++ b/transact-jooq-step-factory/src/main/java/dev/dbos/transact/jooq/JooqStepFactory.java
@@ -9,7 +9,6 @@ import dev.dbos.transact.txstep.StepFactoryOptions;
 import dev.dbos.transact.txstep.TxStepSchema;
 import dev.dbos.transact.workflow.internal.StepResult;
 
-import java.sql.SQLException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -166,10 +165,9 @@ public class JooqStepFactory extends PostgresStepFactory {
         options);
   }
 
-  private static void applyIsolationLevel(Configuration trx, IsolationLevel level)
-      throws SQLException {
+  private static void applyIsolationLevel(Configuration trx, IsolationLevel level) {
     if (level == null || level == IsolationLevel.DEFAULT) return;
-    trx.connectionProvider().acquire().setTransactionIsolation(level.jdbcValue());
+    trx.dsl().execute("SET TRANSACTION ISOLATION LEVEL " + level.sqlName());
   }
 
   @Override

--- a/transact-jooq-step-factory/src/main/java/dev/dbos/transact/jooq/JooqStepFactory.java
+++ b/transact-jooq-step-factory/src/main/java/dev/dbos/transact/jooq/JooqStepFactory.java
@@ -3,10 +3,13 @@ package dev.dbos.transact.jooq;
 import dev.dbos.transact.DBOS;
 import dev.dbos.transact.json.DBOSSerializer;
 import dev.dbos.transact.json.SerializationUtil;
+import dev.dbos.transact.txstep.IsolationLevel;
 import dev.dbos.transact.txstep.PostgresStepFactory;
+import dev.dbos.transact.txstep.StepFactoryOptions;
 import dev.dbos.transact.txstep.TxStepSchema;
 import dev.dbos.transact.workflow.internal.StepResult;
 
+import java.sql.SQLException;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -87,27 +90,44 @@ public class JooqStepFactory extends PostgresStepFactory {
    * @return the value returned by {@code callback}
    */
   public <T> T txStepResult(TransactionalCallable<T> callback, String stepName) {
+    return txStepResult(callback, new StepFactoryOptions(stepName));
+  }
+
+  /**
+   * Executes {@code callback} as an idempotent DBOS step inside a jOOQ transaction.
+   *
+   * <p>Behaves identically to {@link #txStepResult(TransactionalCallable, String)} but accepts a
+   * {@link StepFactoryOptions} to control the step name and transaction isolation level.
+   *
+   * @param <T> the return type of the callback
+   * @param callback the database work to perform; receives a jOOQ {@link Configuration} with an
+   *     open transaction and must not commit or close the underlying connection
+   * @param options step name and optional isolation level override
+   * @return the value returned by {@code callback}
+   */
+  public <T> T txStepResult(TransactionalCallable<T> callback, StepFactoryOptions options) {
     return runTxStep(
         (wfId, stepId) -> {
           try {
             return dsl.transactionResult(
                 trx -> {
+                  applyIsolationLevel(trx, options.isolationLevel());
                   var result = callback.run(trx);
                   recordOutput(trx, wfId, stepId, result);
                   return result;
                 });
           } catch (StepConflictException e) {
-            return checkExecution(wfId, stepId, stepName)
+            return checkExecution(wfId, stepId, options.name())
                 .orElseThrow(
                     () ->
                         new IllegalStateException(
                             "Conflict on tx_step_outputs but winner row not found: workflowId=%s stepId=%d stepName=%s"
-                                .formatted(wfId, stepId, stepName),
+                                .formatted(wfId, stepId, options.name()),
                             e))
                 .<T, RuntimeException>toResult(serializer);
           }
         },
-        stepName);
+        options.name());
   }
 
   /**
@@ -123,12 +143,33 @@ public class JooqStepFactory extends PostgresStepFactory {
    * @param stepName a stable name that identifies this step within the workflow
    */
   public void txStep(TransactionalRunnable transactional, String stepName) {
+    txStep(transactional, new StepFactoryOptions(stepName));
+  }
+
+  /**
+   * Executes {@code transactional} as an idempotent DBOS step inside a jOOQ transaction, with no
+   * return value.
+   *
+   * <p>Behaves identically to {@link #txStepResult(TransactionalCallable, StepFactoryOptions)} but
+   * accepts a {@link TransactionalRunnable} for callers that do not need to return a result.
+   *
+   * @param transactional the database work to perform; receives a jOOQ {@link Configuration} with
+   *     an open transaction and must not commit or close the underlying connection
+   * @param options step name and optional isolation level override
+   */
+  public void txStep(TransactionalRunnable transactional, StepFactoryOptions options) {
     txStepResult(
         c -> {
           transactional.run(c);
           return null;
         },
-        stepName);
+        options);
+  }
+
+  private static void applyIsolationLevel(Configuration trx, IsolationLevel level)
+      throws SQLException {
+    if (level == null || level == IsolationLevel.DEFAULT) return;
+    trx.connectionProvider().acquire().setTransactionIsolation(level.jdbcValue());
   }
 
   @Override

--- a/transact-jooq-step-factory/src/test/java/dev/dbos/transact/jooq/JooqStepFactoryTest.java
+++ b/transact-jooq-step-factory/src/test/java/dev/dbos/transact/jooq/JooqStepFactoryTest.java
@@ -11,6 +11,8 @@ import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.context.WorkflowOptions;
 import dev.dbos.transact.database.SystemDatabase;
 import dev.dbos.transact.json.SerializationUtil;
+import dev.dbos.transact.txstep.IsolationLevel;
+import dev.dbos.transact.txstep.StepFactoryOptions;
 import dev.dbos.transact.utils.DBUtils;
 import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.Workflow;
@@ -44,6 +46,8 @@ interface FactoryTestService {
   TestResult conflictWorkflow(String user) throws SQLException;
 
   TestResult serializationRetryWorkflow(String user);
+
+  String isolationLevelWorkflow(IsolationLevel level);
 }
 
 class FactoryTestServiceImpl implements FactoryTestService {
@@ -123,6 +127,17 @@ class FactoryTestServiceImpl implements FactoryTestService {
           return insertGreeting(ctx.dsl(), user);
         },
         "serializationRetry");
+  }
+
+  @Override
+  @Workflow
+  public String isolationLevelWorkflow(IsolationLevel level) {
+    return stepFactory.<String>txStepResult(
+        trx -> {
+          Object val = trx.dsl().fetchValue("SELECT current_setting('transaction_isolation')");
+          return (String) val;
+        },
+        new StepFactoryOptions("checkIsolation", level));
   }
 
   // Simulates a concurrent winner committing a result while this executor's transaction is still
@@ -472,6 +487,19 @@ public class JooqStepFactoryTest {
     assertEquals(1, rows.size());
     assertNotNull(rows.get(0).output());
     assertNull(rows.get(0).error());
+  }
+
+  @Test
+  public void testIsolationLevel() throws Exception {
+    try (var _o = new WorkflowOptions("wf-iso-ser").setContext()) {
+      assertEquals("serializable", proxy.isolationLevelWorkflow(IsolationLevel.SERIALIZABLE));
+    }
+    try (var _o = new WorkflowOptions("wf-iso-rc").setContext()) {
+      assertEquals("read committed", proxy.isolationLevelWorkflow(IsolationLevel.READ_COMMITTED));
+    }
+    try (var _o = new WorkflowOptions("wf-iso-rr").setContext()) {
+      assertEquals("repeatable read", proxy.isolationLevelWorkflow(IsolationLevel.REPEATABLE_READ));
+    }
   }
 
   @Test

--- a/transact-jooq-step-factory/src/test/java/dev/dbos/transact/jooq/JooqStepFactoryTest.java
+++ b/transact-jooq-step-factory/src/test/java/dev/dbos/transact/jooq/JooqStepFactoryTest.java
@@ -18,6 +18,7 @@ import dev.dbos.transact.workflow.WorkflowHandle;
 
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
@@ -41,6 +42,8 @@ interface FactoryTestService {
   TestResult insertThenReadWorkflow(String user);
 
   TestResult conflictWorkflow(String user) throws SQLException;
+
+  TestResult serializationRetryWorkflow(String user);
 }
 
 class FactoryTestServiceImpl implements FactoryTestService {
@@ -48,6 +51,8 @@ class FactoryTestServiceImpl implements FactoryTestService {
   private final JooqStepFactory stepFactory;
   private final DataSource dataSource;
   final String schema;
+
+  final AtomicInteger retryAttempts = new AtomicInteger();
 
   public FactoryTestServiceImpl(JooqStepFactory stepFactory, DataSource dataSource, String schema) {
     this.stepFactory = stepFactory;
@@ -104,6 +109,20 @@ class FactoryTestServiceImpl implements FactoryTestService {
   public FactoryTestService.TestResult insertThenReadWorkflow(String user) {
     stepFactory.txStep(ctx -> insertGreeting(ctx.dsl(), user), "insertGreeting");
     return stepFactory.txStepResult(ctx -> readGreeting(ctx.dsl(), user), "readGreeting");
+  }
+
+  @Override
+  @Workflow
+  public FactoryTestService.TestResult serializationRetryWorkflow(String user) {
+    return stepFactory.txStepResult(
+        ctx -> {
+          if (retryAttempts.incrementAndGet() <= 2) {
+            throw new RuntimeException(
+                new SQLException("simulated serialization failure", "40001"));
+          }
+          return insertGreeting(ctx.dsl(), user);
+        },
+        "serializationRetry");
   }
 
   // Simulates a concurrent winner committing a result while this executor's transaction is still
@@ -434,6 +453,25 @@ public class JooqStepFactoryTest {
     assertNull(row.error());
     var output = SerializationUtil.deserializeValue(row.output(), row.serialization(), null);
     assertEquals(new FactoryTestService.TestResult(user, 99), output);
+  }
+
+  @Test
+  public void testSerializationRetry() throws Exception {
+    var wfid = "wf-ser-retry";
+    var user = "retryUser";
+
+    try (var _o = new WorkflowOptions(wfid).setContext()) {
+      var result = proxy.serializationRetryWorkflow(user);
+      assertEquals(1, result.greetCount());
+      assertEquals(user, result.user());
+    }
+
+    assertEquals(3, impl.retryAttempts.get()); // 2 failures + 1 success
+    assertEquals(1, getGreetCount(user));
+    var rows = DBUtils.getTxStepRows(dataSource, wfid);
+    assertEquals(1, rows.size());
+    assertNotNull(rows.get(0).output());
+    assertNull(rows.get(0).error());
   }
 
   @Test

--- a/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStep.java
+++ b/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStep.java
@@ -5,6 +5,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.transaction.annotation.Isolation;
+
 /**
  * Marks a Spring-managed method as an idempotent transactional step that integrates with the DBOS
  * runtime.
@@ -31,4 +33,10 @@ import java.lang.annotation.Target;
 public @interface TransactionalStep {
   /** Stable name for this step within the workflow. Defaults to the method name when left empty. */
   String name() default "";
+
+  /**
+   * Transaction isolation level for this step. {@link Isolation#DEFAULT} leaves the
+   * datasource/connection-pool default unchanged.
+   */
+  Isolation isolationLevel() default Isolation.DEFAULT;
 }

--- a/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepAspect.java
+++ b/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepAspect.java
@@ -29,7 +29,6 @@ public class TransactionalStepAspect {
     if (stepName.isEmpty()) {
       stepName = ((MethodSignature) pjp.getSignature()).getName();
     }
-    String resolvedName = stepName;
     try {
       return factory.runTransactionalStep(
           () -> {
@@ -41,7 +40,8 @@ public class TransactionalStepAspect {
               throw new WrappedThrowableException(t);
             }
           },
-          resolvedName);
+          stepName,
+          transactionalStep.isolationLevel());
     } catch (WrappedThrowableException e) {
       throw e.getWrappedThrowable();
     }

--- a/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepFactory.java
+++ b/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepFactory.java
@@ -22,6 +22,7 @@ import javax.sql.DataSource;
 import org.springframework.jdbc.datasource.DataSourceUtils;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 
 /**
@@ -137,9 +138,14 @@ public class TransactionalStepFactory {
    * @param supplier the step body; typically {@code () -> pjp.proceed()} from the aspect
    * @param stepName stable name for the step within the workflow
    */
-  @SuppressWarnings("unchecked")
   public <E extends Exception> Object runTransactionalStep(
       ThrowingSupplier<Object, E> supplier, String stepName) throws E {
+    return runTransactionalStep(supplier, stepName, Isolation.DEFAULT);
+  }
+
+  @SuppressWarnings("unchecked")
+  public <E extends Exception> Object runTransactionalStep(
+      ThrowingSupplier<Object, E> supplier, String stepName, Isolation isolation) throws E {
     // If a @TransactionalStep method is called outside a workflow or inside a step, execute the
     // supplier as a standard @Transactional method without any of the durable execution bookkeeping
     if (!DBOS.inWorkflow() || DBOS.inStep()) {
@@ -173,6 +179,7 @@ public class TransactionalStepFactory {
           long retryWaitMs = 1L;
           while (true) {
             var txDef = new DefaultTransactionDefinition(PROPAGATION_REQUIRES_NEW);
+            txDef.setIsolationLevel(isolation.value());
             TransactionStatus status = txManager.getTransaction(txDef);
             try {
               Object result = supplier.execute();

--- a/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepFactory.java
+++ b/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepFactory.java
@@ -170,28 +170,40 @@ public class TransactionalStepFactory {
             return prev.get().<Object, E>toResult(serializer);
           }
 
-          var txDef = new DefaultTransactionDefinition(PROPAGATION_REQUIRES_NEW);
-          TransactionStatus status = txManager.getTransaction(txDef);
-          try {
-            Object result = supplier.execute();
-            Connection conn = DataSourceUtils.getConnection(dataSource);
-            recordOutput(conn, workflowId, stepId, result);
-            txManager.commit(status);
-            return result;
-          } catch (PostgresStepFactory.StepConflictException conflict) {
-            txManager.rollback(status);
-            return checkExecution(workflowId, stepId, stepName)
-                .orElseThrow(
-                    () ->
-                        new IllegalStateException(
-                            "Conflict on tx_step_outputs but winner row not found: workflowId=%s stepId=%d stepName=%s"
-                                .formatted(workflowId, stepId, stepName),
-                            conflict))
-                .<Object, E>toResult(serializer);
-          } catch (Exception e) {
-            if (!status.isCompleted()) txManager.rollback(status);
-            recordError(workflowId, stepId, e);
-            throw (E) e;
+          long retryWaitMs = 1L;
+          while (true) {
+            var txDef = new DefaultTransactionDefinition(PROPAGATION_REQUIRES_NEW);
+            TransactionStatus status = txManager.getTransaction(txDef);
+            try {
+              Object result = supplier.execute();
+              Connection conn = DataSourceUtils.getConnection(dataSource);
+              recordOutput(conn, workflowId, stepId, result);
+              txManager.commit(status);
+              return result;
+            } catch (PostgresStepFactory.StepConflictException conflict) {
+              if (!status.isCompleted()) txManager.rollback(status);
+              return checkExecution(workflowId, stepId, stepName)
+                  .orElseThrow(
+                      () ->
+                          new IllegalStateException(
+                              "Conflict on tx_step_outputs but winner row not found: workflowId=%s stepId=%d stepName=%s"
+                                  .formatted(workflowId, stepId, stepName),
+                              conflict))
+                  .<Object, E>toResult(serializer);
+            } catch (Exception e) {
+              if (!status.isCompleted()) txManager.rollback(status);
+              if (PostgresStepFactory.isSerializationFailure(e)) {
+                try {
+                  Thread.sleep(retryWaitMs);
+                } catch (InterruptedException ie) {
+                  Thread.currentThread().interrupt();
+                }
+                retryWaitMs = Math.min((long) (retryWaitMs * 1.5), 2000L);
+                continue;
+              }
+              recordError(workflowId, stepId, e);
+              throw (E) e;
+            }
           }
         },
         stepName);

--- a/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepFactory.java
+++ b/transact-spring-txstep-starter/src/main/java/dev/dbos/transact/spring/txstep/TransactionalStepFactory.java
@@ -204,6 +204,7 @@ public class TransactionalStepFactory {
                   Thread.sleep(retryWaitMs);
                 } catch (InterruptedException ie) {
                   Thread.currentThread().interrupt();
+                  throw new RuntimeException("Interrupted during serialization retry backoff", ie);
                 }
                 retryWaitMs = Math.min((long) (retryWaitMs * 1.5), 2000L);
                 continue;

--- a/transact-spring-txstep-starter/src/test/java/dev/dbos/transact/spring/txstep/TransactionalStepJdbcIntegrationTest.java
+++ b/transact-spring-txstep-starter/src/test/java/dev/dbos/transact/spring/txstep/TransactionalStepJdbcIntegrationTest.java
@@ -21,6 +21,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Isolation;
 
 public class TransactionalStepJdbcIntegrationTest {
 
@@ -43,6 +44,11 @@ public class TransactionalStepJdbcIntegrationTest {
     public Order doError(String orderId, String item, int qty) {
       jdbc.update("INSERT INTO orders(id, item, qty) VALUES (?, ?, ?)", orderId, item, qty);
       throw new RuntimeException("intentional failure");
+    }
+
+    @TransactionalStep(isolationLevel = Isolation.SERIALIZABLE)
+    public String checkIsolationLevel() {
+      return jdbc.queryForObject("SELECT current_setting('transaction_isolation')", String.class);
     }
   }
 
@@ -94,6 +100,11 @@ public class TransactionalStepJdbcIntegrationTest {
     @Workflow
     public Order processOrderViaDbosStep(String orderId, String item, int qty) {
       return dbos.runStep(() -> steps.placeOrder(orderId, item, qty), "processOrderViaDbosStep");
+    }
+
+    @Workflow
+    public String checkIsolationLevel() {
+      return steps.checkIsolationLevel();
     }
   }
 
@@ -180,6 +191,21 @@ public class TransactionalStepJdbcIntegrationTest {
                 assertThat(rows).hasSize(1);
                 assertThat(rows.get(0).output()).isNotNull();
                 assertThat(rows.get(0).error()).isNull();
+              });
+    }
+  }
+
+  @Test
+  void isolationLevel() {
+    try (var db = new TransactionalStepTest.TestDatabase()) {
+      runner(db)
+          .run(
+              ctx -> {
+                assertThat(ctx).hasNotFailed();
+                var workflow = ctx.getBean(OrderWorkflowService.class);
+                try (var _o = new WorkflowOptions("wf-jdbc-int-iso").setContext()) {
+                  assertThat(workflow.checkIsolationLevel()).isEqualTo("serializable");
+                }
               });
     }
   }

--- a/transact-spring-txstep-starter/src/test/java/dev/dbos/transact/spring/txstep/TransactionalStepTest.java
+++ b/transact-spring-txstep-starter/src/test/java/dev/dbos/transact/spring/txstep/TransactionalStepTest.java
@@ -38,6 +38,7 @@ import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.annotation.Isolation;
 import org.testcontainers.postgresql.PostgreSQLContainer;
 
 public class TransactionalStepTest {
@@ -209,6 +210,8 @@ public class TransactionalStepTest {
     String insertViaDbosStepWithCheckedException(String name) throws Exception;
 
     String serializationRetry(String name);
+
+    String isolationLevel(Isolation isolation);
   }
 
   static class GreetingServiceImpl implements GreetingService {
@@ -392,6 +395,17 @@ public class TransactionalStepTest {
     }
 
     @Override
+    @Workflow
+    public String isolationLevel(Isolation isolation) {
+      return (String)
+          factory.runTransactionalStep(
+              () ->
+                  jdbc.queryForObject(
+                      "SELECT current_setting('transaction_isolation')", String.class),
+              "checkIsolation",
+              isolation);
+    }
+
     @Workflow
     public String serializationRetry(String name) {
       return (String)
@@ -687,6 +701,19 @@ public class TransactionalStepTest {
 
       assertThat(greetCount(db.dataSource, "dbos-step-checked")).isEqualTo(1);
       assertThat(totalTxRows(db.dataSource)).isEqualTo(0);
+    }
+
+    @Test
+    void isolationLevel() throws Exception {
+      try (var _o = new WorkflowOptions("wf-iso-ser").setContext()) {
+        assertThat(proxy.isolationLevel(Isolation.SERIALIZABLE)).isEqualTo("serializable");
+      }
+      try (var _o = new WorkflowOptions("wf-iso-rc").setContext()) {
+        assertThat(proxy.isolationLevel(Isolation.READ_COMMITTED)).isEqualTo("read committed");
+      }
+      try (var _o = new WorkflowOptions("wf-iso-rr").setContext()) {
+        assertThat(proxy.isolationLevel(Isolation.REPEATABLE_READ)).isEqualTo("repeatable read");
+      }
     }
 
     @Test

--- a/transact-spring-txstep-starter/src/test/java/dev/dbos/transact/spring/txstep/TransactionalStepTest.java
+++ b/transact-spring-txstep-starter/src/test/java/dev/dbos/transact/spring/txstep/TransactionalStepTest.java
@@ -21,6 +21,7 @@ import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
@@ -206,6 +207,8 @@ public class TransactionalStepTest {
     String insertViaDbosStepWithRuntimeError(String name);
 
     String insertViaDbosStepWithCheckedException(String name) throws Exception;
+
+    String serializationRetry(String name);
   }
 
   static class GreetingServiceImpl implements GreetingService {
@@ -213,6 +216,7 @@ public class TransactionalStepTest {
     private final TransactionalStepFactory factory;
     private final JdbcTemplate jdbc;
     private final String schema;
+    final AtomicInteger retryAttempts = new AtomicInteger();
 
     GreetingServiceImpl(
         DBOS dbos, TransactionalStepFactory factory, JdbcTemplate jdbc, String schema) {
@@ -387,6 +391,25 @@ public class TransactionalStepTest {
           "dbosStep");
     }
 
+    @Override
+    @Workflow
+    public String serializationRetry(String name) {
+      return (String)
+          factory.runTransactionalStep(
+              () -> {
+                if (retryAttempts.incrementAndGet() <= 2) {
+                  throw new RuntimeException(
+                      new SQLException("simulated serialization failure", "40001"));
+                }
+                jdbc.update(
+                    "INSERT INTO greetings(name, count) VALUES (?, 1)"
+                        + " ON CONFLICT(name) DO UPDATE SET count = greetings.count + 1",
+                    name);
+                return name;
+              },
+              "serializationRetry");
+    }
+
     // Simulates a concurrent winner committing a result while this executor's transaction is still
     // open. The separate autocommit connection represents the other executor — its INSERT persists
     // even when the Spring transaction manager rolls back the main transaction. When recordOutput
@@ -432,6 +455,7 @@ public class TransactionalStepTest {
     JdbcTemplate jdbc;
     TransactionalStepFactory factory;
     GreetingService proxy;
+    GreetingServiceImpl impl;
 
     @BeforeEach
     void setup() throws SQLException {
@@ -449,7 +473,7 @@ public class TransactionalStepTest {
       factory = new TransactionalStepFactory(dbos, db.dataSource, txManager, null);
       factory.initialize();
 
-      var impl = new GreetingServiceImpl(dbos, factory, jdbc, SystemDatabase.sanitizeSchema(null));
+      impl = new GreetingServiceImpl(dbos, factory, jdbc, SystemDatabase.sanitizeSchema(null));
       proxy = dbos.registerProxy(GreetingService.class, impl);
       dbos.launch();
     }
@@ -663,6 +687,22 @@ public class TransactionalStepTest {
 
       assertThat(greetCount(db.dataSource, "dbos-step-checked")).isEqualTo(1);
       assertThat(totalTxRows(db.dataSource)).isEqualTo(0);
+    }
+
+    @Test
+    void serializationRetry() throws SQLException {
+      var wfid = "wf-ser-retry";
+
+      try (var _o = new WorkflowOptions(wfid).setContext()) {
+        assertThat(proxy.serializationRetry("alice")).isEqualTo("alice");
+      }
+
+      assertThat(impl.retryAttempts.get()).isEqualTo(3); // 2 failures + 1 success
+      assertThat(greetCount(db.dataSource, "alice")).isEqualTo(1);
+      var rows = getTxRows(db.dataSource, wfid);
+      assertThat(rows).hasSize(1);
+      assertThat(rows.get(0).output()).isNotNull();
+      assertThat(rows.get(0).error()).isNull();
     }
 
     // Two executors race to write the result for the same step. The loser detects the 23505

--- a/transact/src/main/java/dev/dbos/transact/txstep/IsolationLevel.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/IsolationLevel.java
@@ -1,0 +1,29 @@
+package dev.dbos.transact.txstep;
+
+import java.sql.Connection;
+
+/**
+ * Transaction isolation levels supported by PostgreSQL.
+ *
+ * <p>Pass as part of {@link StepFactoryOptions} to request a specific isolation level for a
+ * transactional step. {@link #DEFAULT} leaves the connection's isolation level unchanged.
+ */
+public enum IsolationLevel {
+  /** Do not override the connection's isolation level (datasource/pool default). */
+  DEFAULT(-1),
+  READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED),
+  READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED),
+  REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
+  SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE);
+
+  private final int jdbcValue;
+
+  IsolationLevel(int jdbcValue) {
+    this.jdbcValue = jdbcValue;
+  }
+
+  /** The JDBC constant for this level, or {@code -1} for {@link #DEFAULT}. */
+  public int jdbcValue() {
+    return jdbcValue;
+  }
+}

--- a/transact/src/main/java/dev/dbos/transact/txstep/IsolationLevel.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/IsolationLevel.java
@@ -10,20 +10,30 @@ import java.sql.Connection;
  */
 public enum IsolationLevel {
   /** Do not override the connection's isolation level (datasource/pool default). */
-  DEFAULT(-1),
-  READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED),
-  READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED),
-  REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
-  SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE);
+  DEFAULT(-1, null),
+  READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED, "READ UNCOMMITTED"),
+  READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED, "READ COMMITTED"),
+  REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ, "REPEATABLE READ"),
+  SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE, "SERIALIZABLE");
 
   private final int jdbcValue;
+  private final String sqlName;
 
-  IsolationLevel(int jdbcValue) {
+  IsolationLevel(int jdbcValue, String sqlName) {
     this.jdbcValue = jdbcValue;
+    this.sqlName = sqlName;
   }
 
   /** The JDBC constant for this level, or {@code -1} for {@link #DEFAULT}. */
   public int jdbcValue() {
     return jdbcValue;
+  }
+
+  /**
+   * The SQL clause fragment for {@code SET TRANSACTION ISOLATION LEVEL}, or {@code null} for {@link
+   * #DEFAULT}.
+   */
+  public String sqlName() {
+    return sqlName;
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/txstep/JdbcStepFactory.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/JdbcStepFactory.java
@@ -109,28 +109,48 @@ public class JdbcStepFactory extends PostgresStepFactory {
    */
   public <R, X extends Exception> R txStep(
       final TransactionalFunction<R, X> callback, String stepName) throws X {
+    return txStep(callback, new StepFactoryOptions(stepName));
+  }
+
+  /**
+   * Executes {@code callback} as an idempotent DBOS step inside a JDBC transaction.
+   *
+   * <p>Behaves identically to {@link #txStep(TransactionalFunction, String)} but accepts a {@link
+   * StepFactoryOptions} to control the step name and transaction isolation level.
+   *
+   * @param <R> the return type of the callback
+   * @param <X> the checked exception type the callback may throw
+   * @param callback the database work to perform; receives an open {@link Connection} and must not
+   *     commit or close it
+   * @param options step name and optional isolation level override
+   * @return the value returned by {@code callback}
+   * @throws X if the callback throws
+   */
+  public <R, X extends Exception> R txStep(
+      final TransactionalFunction<R, X> callback, StepFactoryOptions options) throws X {
     return runTxStep(
         (wfId, stepId) -> {
           try {
             return executeTransaction(
                 dataSource,
+                options.isolationLevel(),
                 c -> {
                   var result = callback.execute(c);
                   recordOutput(c, wfId, stepId, result);
                   return result;
                 });
           } catch (StepConflictException e) {
-            return checkExecution(wfId, stepId, stepName)
+            return checkExecution(wfId, stepId, options.name())
                 .orElseThrow(
                     () ->
                         new IllegalStateException(
                             "Conflict on tx_step_outputs but winner row not found: workflowId=%s stepId=%d stepName=%s"
-                                .formatted(wfId, stepId, stepName),
+                                .formatted(wfId, stepId, options.name()),
                             e))
                 .<R, X>toResult(serializer);
           }
         },
-        stepName);
+        options.name());
   }
 
   /** Database work that runs inside a JDBC transaction without returning a result. */
@@ -154,21 +174,48 @@ public class JdbcStepFactory extends PostgresStepFactory {
    */
   public <X extends Exception> void txStep(final TransactionalRunnable<X> callback, String stepName)
       throws X {
+    txStep(callback, new StepFactoryOptions(stepName));
+  }
+
+  /**
+   * Executes {@code callback} as an idempotent DBOS step inside a JDBC transaction, with no return
+   * value.
+   *
+   * <p>Behaves identically to {@link #txStep(TransactionalFunction, StepFactoryOptions)} but
+   * accepts a {@link TransactionalRunnable} for callers that do not need to return a result.
+   *
+   * @param <X> the checked exception type the callback may throw
+   * @param callback the database work to perform; receives an open {@link Connection} and must not
+   *     commit or close it
+   * @param options step name and optional isolation level override
+   * @throws X if the callback throws
+   */
+  public <X extends Exception> void txStep(
+      final TransactionalRunnable<X> callback, StepFactoryOptions options) throws X {
     txStep(
         c -> {
           callback.execute(c);
           return null;
         },
-        stepName);
+        options);
   }
 
   private static <R, X extends Exception> R executeTransaction(
       final DataSource ds, TransactionalFunction<R, X> func) throws X {
+    return executeTransaction(ds, IsolationLevel.DEFAULT, func);
+  }
+
+  private static <R, X extends Exception> R executeTransaction(
+      final DataSource ds, IsolationLevel isolationLevel, TransactionalFunction<R, X> func)
+      throws X {
     var conn =
         safeGet(
             () -> {
               var c = ds.getConnection();
               c.setAutoCommit(false);
+              if (isolationLevel != null && isolationLevel != IsolationLevel.DEFAULT) {
+                c.setTransactionIsolation(isolationLevel.jdbcValue());
+              }
               return c;
             });
     try {

--- a/transact/src/main/java/dev/dbos/transact/txstep/PostgresStepFactory.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/PostgresStepFactory.java
@@ -70,6 +70,20 @@ public abstract class PostgresStepFactory {
     return false;
   }
 
+  public static boolean isSerializationFailure(Exception e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof SQLException sq) {
+        var state = sq.getSQLState();
+        if ("40001".equals(state) || "40P01".equals(state)) return true;
+      }
+    }
+    return false;
+  }
+
+  private static final long RETRY_WAIT_INITIAL_MS = 1L;
+  private static final double RETRY_BACKOFF_FACTOR = 1.5;
+  private static final long RETRY_WAIT_MAX_MS = 2000L;
+
   @SuppressWarnings("unchecked")
   protected <R, X extends Exception> R runTxStep(TxStepFunction<R, X> execute, String stepName)
       throws X {
@@ -83,11 +97,24 @@ public abstract class PostgresStepFactory {
             return prev.get().<R, X>toResult(serializer);
           }
 
-          try {
-            return execute.execute(workflowId, stepId);
-          } catch (Exception e) {
-            recordError(workflowId, stepId, e);
-            throw (X) e;
+          long retryWaitMs = RETRY_WAIT_INITIAL_MS;
+          while (true) {
+            try {
+              return execute.execute(workflowId, stepId);
+            } catch (Exception e) {
+              if (isSerializationFailure(e)) {
+                try {
+                  Thread.sleep(retryWaitMs);
+                } catch (InterruptedException ie) {
+                  Thread.currentThread().interrupt();
+                }
+                retryWaitMs =
+                    Math.min((long) (retryWaitMs * RETRY_BACKOFF_FACTOR), RETRY_WAIT_MAX_MS);
+                continue;
+              }
+              recordError(workflowId, stepId, e);
+              throw (X) e;
+            }
           }
         },
         stepName);

--- a/transact/src/main/java/dev/dbos/transact/txstep/PostgresStepFactory.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/PostgresStepFactory.java
@@ -107,6 +107,7 @@ public abstract class PostgresStepFactory {
                   Thread.sleep(retryWaitMs);
                 } catch (InterruptedException ie) {
                   Thread.currentThread().interrupt();
+                  throw new RuntimeException("Interrupted during serialization retry backoff", ie);
                 }
                 retryWaitMs =
                     Math.min((long) (retryWaitMs * RETRY_BACKOFF_FACTOR), RETRY_WAIT_MAX_MS);

--- a/transact/src/main/java/dev/dbos/transact/txstep/StepFactoryOptions.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/StepFactoryOptions.java
@@ -1,0 +1,16 @@
+package dev.dbos.transact.txstep;
+
+/**
+ * Options for a transactional step executed via a step factory.
+ *
+ * @param name the stable step name used for idempotency tracking within the workflow
+ * @param isolationLevel the transaction isolation level to request; {@link IsolationLevel#DEFAULT}
+ *     leaves the connection's level unchanged
+ */
+public record StepFactoryOptions(String name, IsolationLevel isolationLevel) {
+
+  /** Creates options with {@link IsolationLevel#DEFAULT} (no override). */
+  public StepFactoryOptions(String name) {
+    this(name, IsolationLevel.DEFAULT);
+  }
+}

--- a/transact/src/test/java/dev/dbos/transact/txstep/JdbcStepFactoryTest.java
+++ b/transact/src/test/java/dev/dbos/transact/txstep/JdbcStepFactoryTest.java
@@ -18,6 +18,7 @@ import dev.dbos.transact.workflow.WorkflowHandle;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
@@ -38,12 +39,16 @@ interface FactoryTestService {
   TestResult insertThenReadWorkflow(String user) throws SQLException;
 
   TestResult conflictWorkflow(String user) throws SQLException;
+
+  TestResult serializationRetryWorkflow(String user) throws SQLException;
 }
 
 class FactoryTestServiceImpl implements FactoryTestService {
 
   private final JdbcStepFactory stepFactory;
   private final DataSource dataSource;
+
+  final AtomicInteger retryAttempts = new AtomicInteger();
 
   public FactoryTestServiceImpl(JdbcStepFactory stepFactory, DataSource dataSource) {
     this.stepFactory = stepFactory;
@@ -113,6 +118,19 @@ class FactoryTestServiceImpl implements FactoryTestService {
   public TestResult insertThenReadWorkflow(String user) throws SQLException {
     stepFactory.txStep((Connection c) -> insertGreeting(c, user), "insertGreeting");
     return stepFactory.txStep((Connection c) -> readGreeting(c, user), "readGreeting");
+  }
+
+  @Override
+  @Workflow
+  public TestResult serializationRetryWorkflow(String user) throws SQLException {
+    return stepFactory.txStep(
+        (Connection c) -> {
+          if (retryAttempts.incrementAndGet() <= 2) {
+            throw new SQLException("simulated serialization failure", "40001");
+          }
+          return insertGreeting(c, user);
+        },
+        "serializationRetry");
   }
 
   // Simulates a concurrent winner committing a result while this executor's transaction is still
@@ -443,6 +461,25 @@ public class JdbcStepFactoryTest {
     assertNull(row.error());
     var output = SerializationUtil.deserializeValue(row.output(), row.serialization(), null);
     assertEquals(new FactoryTestService.TestResult(user, 99), output);
+  }
+
+  @Test
+  public void testSerializationRetry() throws Exception {
+    var wfid = "wf-ser-retry";
+    var user = "retryUser";
+
+    try (var _o = new WorkflowOptions(wfid).setContext()) {
+      var result = proxy.serializationRetryWorkflow(user);
+      assertEquals(1, result.greetCount());
+      assertEquals(user, result.user());
+    }
+
+    assertEquals(3, impl.retryAttempts.get()); // 2 failures + 1 success
+    assertEquals(1, getGreetCount(user));
+    var rows = DBUtils.getTxStepRows(dataSource, wfid);
+    assertEquals(1, rows.size());
+    assertNotNull(rows.get(0).output());
+    assertNull(rows.get(0).error());
   }
 
   @Test

--- a/transact/src/test/java/dev/dbos/transact/txstep/JdbcStepFactoryTest.java
+++ b/transact/src/test/java/dev/dbos/transact/txstep/JdbcStepFactoryTest.java
@@ -41,6 +41,8 @@ interface FactoryTestService {
   TestResult conflictWorkflow(String user) throws SQLException;
 
   TestResult serializationRetryWorkflow(String user) throws SQLException;
+
+  String isolationLevelWorkflow(IsolationLevel level) throws SQLException;
 }
 
 class FactoryTestServiceImpl implements FactoryTestService {
@@ -155,6 +157,21 @@ class FactoryTestServiceImpl implements FactoryTestService {
       stmt.executeUpdate();
     }
     return insertGreeting(conn, user);
+  }
+
+  @Override
+  @Workflow
+  public String isolationLevelWorkflow(IsolationLevel level) throws SQLException {
+    return stepFactory.txStep(
+        c -> {
+          try (var stmt = c.prepareStatement("SELECT current_setting('transaction_isolation')")) {
+            try (var rs = stmt.executeQuery()) {
+              rs.next();
+              return rs.getString(1);
+            }
+          }
+        },
+        new StepFactoryOptions("checkIsolation", level));
   }
 
   @Override
@@ -480,6 +497,19 @@ public class JdbcStepFactoryTest {
     assertEquals(1, rows.size());
     assertNotNull(rows.get(0).output());
     assertNull(rows.get(0).error());
+  }
+
+  @Test
+  public void testIsolationLevel() throws Exception {
+    try (var _o = new WorkflowOptions("wf-iso-ser").setContext()) {
+      assertEquals("serializable", proxy.isolationLevelWorkflow(IsolationLevel.SERIALIZABLE));
+    }
+    try (var _o = new WorkflowOptions("wf-iso-rc").setContext()) {
+      assertEquals("read committed", proxy.isolationLevelWorkflow(IsolationLevel.READ_COMMITTED));
+    }
+    try (var _o = new WorkflowOptions("wf-iso-rr").setContext()) {
+      assertEquals("repeatable read", proxy.isolationLevelWorkflow(IsolationLevel.REPEATABLE_READ));
+    }
   }
 
   @Test

--- a/transact/src/test/java/dev/dbos/transact/txstep/JdbcStepFactoryTest.java
+++ b/transact/src/test/java/dev/dbos/transact/txstep/JdbcStepFactoryTest.java
@@ -508,7 +508,9 @@ public class JdbcStepFactoryTest {
       assertEquals("read committed", proxy.isolationLevelWorkflow(IsolationLevel.READ_COMMITTED));
     }
     try (var _o = new WorkflowOptions("wf-iso-rr").setContext()) {
-      assertEquals("repeatable read", proxy.isolationLevelWorkflow(IsolationLevel.REPEATABLE_READ));
+      // CRDB upgrades REPEATABLE READ to SERIALIZABLE
+      var expected = PgContainer.USE_COCKROACH_DB ? "serializable" : "repeatable read";
+      assertEquals(expected, proxy.isolationLevelWorkflow(IsolationLevel.REPEATABLE_READ));
     }
   }
 


### PR DESCRIPTION
This PR adds the ability to specify tx isolation level when executing a transactional step. Each factory uses the idiom that feels natural for its library.

Additionally, this PR automatically retries Tx Steps that fail with 40001 (serialization failure) or 40P01 (deadlock detected)

fixes #417