### PR TITLE
Step Should Retry support

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -1210,8 +1210,18 @@ public class DBOSExecutor implements AutoCloseable {
       }
 
       var shouldRetry = options.shouldRetry();
-      if (exception != null && shouldRetry != null && !shouldRetry.test(exception)) {
-        break;
+      if (exception != null && shouldRetry != null) {
+        try {
+          if (!shouldRetry.test(exception)) {
+            break;
+          }
+        } catch (Exception predicateEx) {
+          logger.warn(
+              "shouldRetry predicate threw for step {} in workflow {}; treating as retry",
+              options.name(),
+              workflowId,
+              predicateEx);
+        }
       }
 
       try {

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -1209,6 +1209,11 @@ public class DBOSExecutor implements AutoCloseable {
         break;
       }
 
+      var shouldRetry = options.shouldRetry();
+      if (exception != null && shouldRetry != null && !shouldRetry.test(exception)) {
+        break;
+      }
+
       try {
         Thread.sleep(retryInterval.toMillis());
       } catch (InterruptedException e) {

--- a/transact/src/main/java/dev/dbos/transact/workflow/Step.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/Step.java
@@ -15,4 +15,6 @@ public @interface Step {
   double intervalSeconds() default StepOptions.DEFAULT_INTERVAL_SECONDS;
 
   double backOffRate() default StepOptions.DEFAULT_BACKOFF;
+
+  Class<? extends StepShouldRetry> shouldRetry() default StepShouldRetry.None.class;
 }

--- a/transact/src/main/java/dev/dbos/transact/workflow/StepOptions.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/StepOptions.java
@@ -53,11 +53,14 @@ public record StepOptions(
     }
 
     try {
-      var constructor = shouldRetryClass.getDeclaredConstructor();
-      constructor.setAccessible(true);
-      var instance = constructor.newInstance();
+      var instance = shouldRetryClass.getConstructor().newInstance();
       return new StepOptions(
           name, maxAttempts, interval, stepTag.backOffRate(), instance::shouldRetry);
+    } catch (NoSuchMethodException ex) {
+      throw new RuntimeException(
+          "%s must be a public class with a public no-arg constructor"
+              .formatted(shouldRetryClass.getName()),
+          ex);
     } catch (Exception ex) {
       throw new RuntimeException(
           "Failed to instantiate shouldRetry class: " + shouldRetryClass.getName(), ex);

--- a/transact/src/main/java/dev/dbos/transact/workflow/StepOptions.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/StepOptions.java
@@ -3,11 +3,16 @@ package dev.dbos.transact.workflow;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.function.Predicate;
 
 import org.jspecify.annotations.NonNull;
 
 public record StepOptions(
-    String name, int maxAttempts, Duration retryInterval, double backOffRate) {
+    String name,
+    int maxAttempts,
+    Duration retryInterval,
+    double backOffRate,
+    Predicate<Throwable> shouldRetry) {
 
   public static final double DEFAULT_INTERVAL_SECONDS = 1.0;
   public static final double DEFAULT_BACKOFF = 2.0;
@@ -29,26 +34,50 @@ public record StepOptions(
         name,
         1,
         Duration.ofSeconds((long) StepOptions.DEFAULT_INTERVAL_SECONDS),
-        StepOptions.DEFAULT_BACKOFF);
+        StepOptions.DEFAULT_BACKOFF,
+        null);
   }
 
   public static StepOptions create(Step stepTag, Method method) {
     var name = stepTag.name().isEmpty() ? method.getName() : stepTag.name();
     var maxAttempts = stepTag.maxAttempts() < 1 ? 1 : stepTag.maxAttempts();
     var interval = Duration.ofMillis((long) (stepTag.intervalSeconds() * 1000));
-    return new StepOptions(name, maxAttempts, interval, stepTag.backOffRate());
+
+    var shouldRetryClass = stepTag.shouldRetry();
+    if (shouldRetryClass.equals(StepShouldRetry.None.class)) {
+      return new StepOptions(name, maxAttempts, interval, stepTag.backOffRate(), null);
+    }
+
+    try {
+      var constructor = shouldRetryClass.getDeclaredConstructor();
+      constructor.setAccessible(true);
+      var instance = constructor.newInstance();
+      return new StepOptions(
+          name, maxAttempts, interval, stepTag.backOffRate(), instance::shouldRetry);
+    } catch (Exception ex) {
+      throw new RuntimeException(
+          "Failed to instantiate shouldRetry class: " + shouldRetryClass.getName(), ex);
+    }
   }
 
   public StepOptions withMaxAttempts(int maxAttempts) {
-    return new StepOptions(this.name, maxAttempts, this.retryInterval, this.backOffRate);
+    return new StepOptions(
+        this.name, maxAttempts, this.retryInterval, this.backOffRate, this.shouldRetry);
   }
 
   public StepOptions withRetryInterval(Duration interval) {
-    return new StepOptions(this.name, this.maxAttempts, interval, this.backOffRate);
+    return new StepOptions(
+        this.name, this.maxAttempts, interval, this.backOffRate, this.shouldRetry);
   }
 
   public StepOptions withBackoffRate(double backOffRate) {
-    return new StepOptions(this.name, this.maxAttempts, this.retryInterval, backOffRate);
+    return new StepOptions(
+        this.name, this.maxAttempts, this.retryInterval, backOffRate, this.shouldRetry);
+  }
+
+  public StepOptions withShouldRetry(Predicate<Throwable> shouldRetry) {
+    return new StepOptions(
+        this.name, this.maxAttempts, this.retryInterval, this.backOffRate, shouldRetry);
   }
 
   @Override

--- a/transact/src/main/java/dev/dbos/transact/workflow/StepOptions.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/StepOptions.java
@@ -29,6 +29,10 @@ public record StepOptions(
     }
   }
 
+  public StepOptions(String name, int maxAttempts, Duration retryInterval, double backOffRate) {
+    this(name, maxAttempts, retryInterval, backOffRate, null);
+  }
+
   public StepOptions(String name) {
     this(
         name,
@@ -45,7 +49,7 @@ public record StepOptions(
 
     var shouldRetryClass = stepTag.shouldRetry();
     if (shouldRetryClass.equals(StepShouldRetry.None.class)) {
-      return new StepOptions(name, maxAttempts, interval, stepTag.backOffRate(), null);
+      return new StepOptions(name, maxAttempts, interval, stepTag.backOffRate());
     }
 
     try {

--- a/transact/src/main/java/dev/dbos/transact/workflow/StepShouldRetry.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/StepShouldRetry.java
@@ -1,0 +1,13 @@
+package dev.dbos.transact.workflow;
+
+@FunctionalInterface
+public interface StepShouldRetry {
+  boolean shouldRetry(Throwable e);
+
+  class None implements StepShouldRetry {
+    @Override
+    public boolean shouldRetry(Throwable e) {
+      return true;
+    }
+  }
+}

--- a/transact/src/test/java/dev/dbos/transact/step/RejectFatalExceptions.java
+++ b/transact/src/test/java/dev/dbos/transact/step/RejectFatalExceptions.java
@@ -1,0 +1,10 @@
+package dev.dbos.transact.step;
+
+import dev.dbos.transact.workflow.StepShouldRetry;
+
+public class RejectFatalExceptions implements StepShouldRetry {
+  @Override
+  public boolean shouldRetry(Throwable e) {
+    return !(e instanceof FatalStepException);
+  }
+}

--- a/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
+++ b/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
@@ -148,6 +148,8 @@ interface ServiceWFAndStep {
   String shouldRetryRetryableWorkflow(String input);
 
   String inlineShouldRetryRetryableWorkflow(String input);
+
+  String throwingPredicateWorkflow(String input);
 }
 
 class ServiceWFAndStepImpl implements ServiceWFAndStep {
@@ -411,6 +413,31 @@ class ServiceWFAndStepImpl implements ServiceWFAndStep {
       caught = true;
     }
     return caught ? "runs:" + inlineShouldRetryRetryableStepRuns : "should have thrown";
+  }
+
+  int throwingPredicateStepRuns = 0;
+
+  @Override
+  @Workflow(name = "throwingPredicateWorkflow")
+  public String throwingPredicateWorkflow(String input) {
+    boolean caught = false;
+    try {
+      dbos.runStep(
+          () -> {
+            ++throwingPredicateStepRuns;
+            throw new RuntimeException("step error");
+          },
+          new StepOptions("throwingPredicateStep")
+              .withMaxAttempts(3)
+              .withRetryInterval(Duration.ofMillis(10))
+              .withShouldRetry(
+                  e -> {
+                    throw new RuntimeException("predicate error");
+                  }));
+    } catch (Exception e) {
+      caught = true;
+    }
+    return caught ? "runs:" + throwingPredicateStepRuns : "should have thrown";
   }
 }
 
@@ -729,5 +756,21 @@ public class StepsTest {
     var handle = dbos.retrieveWorkflow(workflowId);
     // shouldRetry lambda returns true for RuntimeException, so all maxAttempts=4 are consumed
     assertEquals("runs:4", (String) handle.getResult());
+  }
+
+  @Test
+  public void throwingPredicateTreatedAsRetry() throws Exception {
+    ServiceWFAndStep service =
+        dbos.registerProxy(ServiceWFAndStep.class, new ServiceWFAndStepImpl(dbos));
+    dbos.launch();
+
+    String workflowId = "wf-throwing-predicate-1234";
+    try (var id = new WorkflowOptions(workflowId).setContext()) {
+      service.throwingPredicateWorkflow("input");
+    }
+
+    var handle = dbos.retrieveWorkflow(workflowId);
+    // predicate always throws, so it is treated as "retry" and all maxAttempts=3 are consumed
+    assertEquals("runs:3", (String) handle.getResult());
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
+++ b/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
@@ -118,13 +118,6 @@ class FatalStepException extends RuntimeException {
   }
 }
 
-class RejectFatalExceptions implements StepShouldRetry {
-  @Override
-  public boolean shouldRetry(Throwable e) {
-    return !(e instanceof FatalStepException);
-  }
-}
-
 interface ServiceWFAndStep {
   String aWorkflow(String input);
 

--- a/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
+++ b/transact/src/test/java/dev/dbos/transact/step/StepsTest.java
@@ -112,6 +112,19 @@ class ServiceBImpl implements ServiceB {
   }
 }
 
+class FatalStepException extends RuntimeException {
+  FatalStepException(String msg) {
+    super(msg);
+  }
+}
+
+class RejectFatalExceptions implements StepShouldRetry {
+  @Override
+  public boolean shouldRetry(Throwable e) {
+    return !(e instanceof FatalStepException);
+  }
+}
+
 interface ServiceWFAndStep {
   String aWorkflow(String input);
 
@@ -130,6 +143,18 @@ interface ServiceWFAndStep {
   String stepRetryWorkflow(String input);
 
   String inlineStepRetryWorkflow(String input);
+
+  String stepWithShouldRetry(String input) throws Exception;
+
+  String shouldRetryWorkflow(String input);
+
+  String inlineShouldRetryWorkflow(String input);
+
+  String stepWithRetryableError(String input) throws Exception;
+
+  String shouldRetryRetryableWorkflow(String input);
+
+  String inlineShouldRetryRetryableWorkflow(String input);
 }
 
 class ServiceWFAndStepImpl implements ServiceWFAndStep {
@@ -297,6 +322,102 @@ class ServiceWFAndStepImpl implements ServiceWFAndStep {
     result += ".";
 
     return result;
+  }
+
+  int stepWithShouldRetryRuns = 0;
+
+  @Override
+  @Step(
+      name = "stepWithShouldRetry",
+      maxAttempts = 4,
+      intervalSeconds = .01,
+      backOffRate = 1,
+      shouldRetry = RejectFatalExceptions.class)
+  public String stepWithShouldRetry(String input) throws Exception {
+    ++stepWithShouldRetryRuns;
+    throw new FatalStepException("fatal error");
+  }
+
+  @Override
+  @Workflow(name = "shouldRetryWorkflow")
+  public String shouldRetryWorkflow(String input) {
+    boolean caught = false;
+    try {
+      self.stepWithShouldRetry(input);
+    } catch (Exception e) {
+      caught = true;
+    }
+    return caught ? "runs:" + stepWithShouldRetryRuns : "should have thrown";
+  }
+
+  int inlineShouldRetryStepRuns = 0;
+
+  @Override
+  @Workflow(name = "inlineShouldRetryWorkflow")
+  public String inlineShouldRetryWorkflow(String input) {
+    boolean caught = false;
+    try {
+      dbos.runStep(
+          () -> {
+            ++inlineShouldRetryStepRuns;
+            throw new FatalStepException("fatal");
+          },
+          new StepOptions("inlineShouldRetryStep")
+              .withMaxAttempts(4)
+              .withRetryInterval(Duration.ofMillis(10))
+              .withShouldRetry(e -> !(e instanceof FatalStepException)));
+    } catch (Exception e) {
+      caught = true;
+    }
+    return caught ? "runs:" + inlineShouldRetryStepRuns : "should have thrown";
+  }
+
+  int stepWithRetryableErrorRuns = 0;
+
+  @Override
+  @Step(
+      name = "stepWithRetryableError",
+      maxAttempts = 4,
+      intervalSeconds = .01,
+      backOffRate = 1,
+      shouldRetry = RejectFatalExceptions.class)
+  public String stepWithRetryableError(String input) throws Exception {
+    ++stepWithRetryableErrorRuns;
+    throw new RuntimeException("retryable error");
+  }
+
+  @Override
+  @Workflow(name = "shouldRetryRetryableWorkflow")
+  public String shouldRetryRetryableWorkflow(String input) {
+    boolean caught = false;
+    try {
+      self.stepWithRetryableError(input);
+    } catch (Exception e) {
+      caught = true;
+    }
+    return caught ? "runs:" + stepWithRetryableErrorRuns : "should have thrown";
+  }
+
+  int inlineShouldRetryRetryableStepRuns = 0;
+
+  @Override
+  @Workflow(name = "inlineShouldRetryRetryableWorkflow")
+  public String inlineShouldRetryRetryableWorkflow(String input) {
+    boolean caught = false;
+    try {
+      dbos.runStep(
+          () -> {
+            ++inlineShouldRetryRetryableStepRuns;
+            throw new RuntimeException("retryable");
+          },
+          new StepOptions("inlineShouldRetryRetryableStep")
+              .withMaxAttempts(4)
+              .withRetryInterval(Duration.ofMillis(10))
+              .withShouldRetry(e -> !(e instanceof FatalStepException)));
+    } catch (Exception e) {
+      caught = true;
+    }
+    return caught ? "runs:" + inlineShouldRetryRetryableStepRuns : "should have thrown";
   }
 }
 
@@ -547,5 +668,73 @@ public class StepsTest {
     var handle = dbos.retrieveWorkflow(workflowId);
     String expectedRes = "2 Retries: 2.";
     assertEquals(expectedRes, (String) handle.getResult());
+  }
+
+  @Test
+  public void shouldRetryAnnotationAbortsOnFatalException() throws Exception {
+    ServiceWFAndStepImpl impl = new ServiceWFAndStepImpl(dbos);
+    ServiceWFAndStep service = dbos.registerProxy(ServiceWFAndStep.class, impl);
+    dbos.launch();
+    impl.setSelf(service);
+
+    String workflowId = "wf-shouldretry-annotation-1234";
+    try (var id = new WorkflowOptions(workflowId).setContext()) {
+      service.shouldRetryWorkflow("input");
+    }
+
+    var handle = dbos.retrieveWorkflow(workflowId);
+    // shouldRetry returns false for FatalStepException, so step runs exactly once despite
+    // maxAttempts=4
+    assertEquals("runs:1", (String) handle.getResult());
+  }
+
+  @Test
+  public void shouldRetryInlineAbortsOnFatalException() throws Exception {
+    ServiceWFAndStep service =
+        dbos.registerProxy(ServiceWFAndStep.class, new ServiceWFAndStepImpl(dbos));
+    dbos.launch();
+
+    String workflowId = "wf-shouldretry-inline-1234";
+    try (var id = new WorkflowOptions(workflowId).setContext()) {
+      service.inlineShouldRetryWorkflow("input");
+    }
+
+    var handle = dbos.retrieveWorkflow(workflowId);
+    // shouldRetry lambda returns false for FatalStepException, so step runs exactly once despite
+    // maxAttempts=4
+    assertEquals("runs:1", (String) handle.getResult());
+  }
+
+  @Test
+  public void shouldRetryRetryableExhaustsAllAttempts() throws Exception {
+    ServiceWFAndStepImpl impl = new ServiceWFAndStepImpl(dbos);
+    ServiceWFAndStep service = dbos.registerProxy(ServiceWFAndStep.class, impl);
+    dbos.launch();
+    impl.setSelf(service);
+
+    String workflowId = "wf-shouldretry-retryable-annotation-1234";
+    try (var id = new WorkflowOptions(workflowId).setContext()) {
+      service.shouldRetryRetryableWorkflow("input");
+    }
+
+    var handle = dbos.retrieveWorkflow(workflowId);
+    // shouldRetry returns true for RuntimeException, so all maxAttempts=4 are consumed
+    assertEquals("runs:4", (String) handle.getResult());
+  }
+
+  @Test
+  public void shouldRetryInlineRetryableExhaustsAllAttempts() throws Exception {
+    ServiceWFAndStep service =
+        dbos.registerProxy(ServiceWFAndStep.class, new ServiceWFAndStepImpl(dbos));
+    dbos.launch();
+
+    String workflowId = "wf-shouldretry-retryable-inline-1234";
+    try (var id = new WorkflowOptions(workflowId).setContext()) {
+      service.inlineShouldRetryRetryableWorkflow("input");
+    }
+
+    var handle = dbos.retrieveWorkflow(workflowId);
+    // shouldRetry lambda returns true for RuntimeException, so all maxAttempts=4 are consumed
+    assertEquals("runs:4", (String) handle.getResult());
   }
 }


### PR DESCRIPTION
Adds a shouldRetry predicate to steps, allowing callers to short-circuit retries on specific exception types rather than always exhausting maxAttempts.

Two ways to specify the predicate:
- Annotation (`@Step`): provide a `Class<? extends StepShouldRetry>` — the class is instantiated via reflection at runtime. StepShouldRetry is a functional interface w/ `boolean shouldRetry(Throwable)` method.

```java
@Step(maxAttempts = 5, shouldRetry = MyRetryPolicy.class)
public String myStep(String input) { ... }
```

- Programmatic (`StepOptions`): pass a Predicate<Throwable> directly, suitable for inline steps or lambdas.

```java
dbos.runStep(
  () -> { ... },
  new StepOptions("myStep")
    .withMaxAttempts(5)
    .withShouldRetry(e -> !(e instanceof FatalException)));
```
  When shouldRetry returns false, the step aborts immediately and rethrows the original exception. When it returns true (or is not set), normal retry-with-backoff behavior applies.

Implementation notes
  - StepShouldRetry.None is a sentinel inner class used as the annotation default, since Java annotations cannot use null as an element default value.
  - StepShouldRetry implementers must have a public no-arg constructor

fixes #413