### PR TITLE
Listen/Notify for readStream

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/database/NotificationListenerSource.java
+++ b/transact/src/main/java/dev/dbos/transact/database/NotificationListenerSource.java
@@ -42,6 +42,12 @@ class NotificationListenerSource implements NotificationSource {
   }
 
   @Override
+  public Subscription subscribe(SignalKey.Stream key) {
+    var strKey = "s::%s::%s".formatted(key.workflowId(), key.key());
+    return signalMap.subscribe(strKey, key.wakeReason());
+  }
+
+  @Override
   public void start() {
     Thread t = new Thread(this::notificationListener, "NotificationListener");
     t.setDaemon(true);
@@ -81,6 +87,7 @@ class NotificationListenerSource implements NotificationSource {
         try (Statement stmt = notificationConnection.createStatement()) {
           stmt.execute("LISTEN dbos_notifications_channel");
           stmt.execute("LISTEN dbos_workflow_events_channel");
+          stmt.execute("LISTEN dbos_streams_channel");
         }
 
         logger.debug("Listening for PostgreSQL notifications");
@@ -102,6 +109,7 @@ class NotificationListenerSource implements NotificationSource {
                 switch (channel) {
                   case "dbos_notifications_channel" -> signalMap.signal("m::" + payload);
                   case "dbos_workflow_events_channel" -> signalMap.signal("e::" + payload);
+                  case "dbos_streams_channel" -> signalMap.signal("s::" + payload);
                   default -> logger.error("Unknown NOTIFY channel: {}", channel);
                 }
             }

--- a/transact/src/main/java/dev/dbos/transact/database/StreamIterator.java
+++ b/transact/src/main/java/dev/dbos/transact/database/StreamIterator.java
@@ -1,8 +1,5 @@
 package dev.dbos.transact.database;
 
-import dev.dbos.transact.workflow.WorkflowState;
-import dev.dbos.transact.workflow.WorkflowStatus;
-
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -18,55 +15,29 @@ public class StreamIterator implements Iterator<Object> {
     this.workflowId = workflowId;
     this.key = key;
     this.systemDatabase = systemDatabase;
-    advance();
-  }
-
-  private void advance() {
-    while (!finished) {
-      try {
-        Object value = systemDatabase.readStream(workflowId, key, offset);
-        nextValue = value;
-        offset++;
-        return;
-      } catch (IllegalArgumentException e) {
-        WorkflowStatus status = systemDatabase.getWorkflowStatus(workflowId);
-        if (status == null || !isWorkflowActive(status.status())) {
-          finished = true;
-          nextValue = null;
-          return;
-        }
-        try {
-          Thread.sleep(1000);
-        } catch (InterruptedException ie) {
-          Thread.currentThread().interrupt();
-          finished = true;
-          nextValue = null;
-          return;
-        }
-      } catch (IllegalStateException e) {
-        finished = true;
-        nextValue = null;
-        return;
-      }
-    }
-  }
-
-  private boolean isWorkflowActive(WorkflowState state) {
-    return WorkflowState.PENDING == state || WorkflowState.ENQUEUED == state;
   }
 
   @Override
   public boolean hasNext() {
-    return nextValue != null;
+    if (!finished && nextValue == null) {
+      Object value = systemDatabase.readStream(workflowId, key, offset);
+      if (value == SystemDatabase.END_OF_STREAM) {
+        finished = true;
+      } else {
+        nextValue = value;
+        offset++;
+      }
+    }
+    return !finished;
   }
 
   @Override
   public Object next() {
-    if (nextValue == null) {
+    if (!hasNext()) {
       throw new NoSuchElementException();
     }
     Object result = nextValue;
-    advance();
+    nextValue = null;
     return result;
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/database/StreamIterator.java
+++ b/transact/src/main/java/dev/dbos/transact/database/StreamIterator.java
@@ -20,12 +20,16 @@ public class StreamIterator implements Iterator<Object> {
   @Override
   public boolean hasNext() {
     if (!finished && nextValue == null) {
-      Object value = systemDatabase.readStream(workflowId, key, offset);
-      if (value == SystemDatabase.END_OF_STREAM) {
+      try {
+        Object value = systemDatabase.readStream(workflowId, key, offset);
+        if (value == SystemDatabase.END_OF_STREAM) {
+          finished = true;
+        } else {
+          nextValue = value;
+          offset++;
+        }
+      } catch (IllegalStateException e) {
         finished = true;
-      } else {
-        nextValue = value;
-        offset++;
       }
     }
     return !finished;

--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -53,10 +53,14 @@ import org.slf4j.LoggerFactory;
 
 public class SystemDatabase implements AutoCloseable {
 
+  public static final Object END_OF_STREAM = new Object();
+
   public interface NotificationRegistry {
     Subscription subscribe(SignalKey.Message key);
 
     Subscription subscribe(SignalKey.Event key);
+
+    Subscription subscribe(SignalKey.Stream key);
   }
 
   public interface NotificationSource extends NotificationRegistry {
@@ -74,6 +78,11 @@ public class SystemDatabase implements AutoCloseable {
 
     @Override
     public Subscription subscribe(Event key) {
+      return new Subscription(() -> {});
+    }
+
+    @Override
+    public Subscription subscribe(SignalKey.Stream key) {
       return new Subscription(() -> {});
     }
 
@@ -684,7 +693,10 @@ public class SystemDatabase implements AutoCloseable {
   }
 
   public Object readStream(String workflowId, String key, int offset) {
-    return dbRetry(() -> StreamsDAO.readStream(ctx, workflowId, key, offset));
+    return dbRetry(
+        () ->
+            StreamsDAO.readStream(
+                ctx, workflowId, key, offset, dbPollingInterval, notificationSource));
   }
 
   public Map<String, List<Object>> getAllStreamEntries(String workflowId) {

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StreamsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StreamsDAO.java
@@ -156,49 +156,29 @@ public class StreamsDAO {
 
     while (true) {
       ctx.checkClosed();
-      try (var sub = notificationRegistry.subscribe(new SignalKey.Stream(workflowId, key));
-          var conn = ctx.getConnection();
-          var stmt = conn.prepareStatement(sql)) {
-        stmt.setString(1, workflowId);
-        stmt.setString(2, key);
-        stmt.setInt(3, offset);
-        try (var rs = stmt.executeQuery()) {
-          if (rs.next()) {
-            String value = rs.getString("value");
-            String serialization = rs.getString("serialization");
-            Object deserialized = SerializationUtil.deserializeValue(value, serialization, null);
-            if (STREAM_CLOSED_SENTINEL.equals(deserialized)) {
-              throw new IllegalStateException("Stream is closed: " + key);
+      try (var sub = notificationRegistry.subscribe(new SignalKey.Stream(workflowId, key))) {
+        try (var conn = ctx.getConnection();
+            var stmt = conn.prepareStatement(sql)) {
+          stmt.setString(1, workflowId);
+          stmt.setString(2, key);
+          stmt.setInt(3, offset);
+          try (var rs = stmt.executeQuery()) {
+            if (rs.next()) {
+              String value = rs.getString("value");
+              String serialization = rs.getString("serialization");
+              Object deserialized = SerializationUtil.deserializeValue(value, serialization, null);
+              if (STREAM_CLOSED_SENTINEL.equals(deserialized)) {
+                return SystemDatabase.END_OF_STREAM;
+              }
+              return deserialized;
             }
-            return deserialized;
+          }
+          WorkflowStatus status = WorkflowDAO.getWorkflowStatus(ctx, workflowId);
+          if (status == null || !status.status().isActive()) {
+            return SystemDatabase.END_OF_STREAM;
           }
         }
-        if (!streamKeyExists(conn, ctx.schema(), workflowId, key)) {
-          throw new IllegalArgumentException("Stream key not found: " + key);
-        }
-        WorkflowStatus status = WorkflowDAO.getWorkflowStatus(ctx, workflowId);
-        if (status == null || !status.status().isActive()) {
-          return SystemDatabase.END_OF_STREAM;
-        }
         SignalMap.awaitAny(dbPollingInterval, sub);
-      }
-    }
-  }
-
-  private static boolean streamKeyExists(
-      Connection conn, String schema, String workflowId, String key) throws SQLException {
-    String sql =
-        """
-        SELECT 1 FROM "%s".streams
-        WHERE workflow_uuid = ? AND key = ?
-        LIMIT 1
-        """
-            .formatted(schema);
-    try (var stmt = conn.prepareStatement(sql)) {
-      stmt.setString(1, workflowId);
-      stmt.setString(2, key);
-      try (var rs = stmt.executeQuery()) {
-        return rs.next();
       }
     }
   }

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StreamsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StreamsDAO.java
@@ -1,11 +1,17 @@
 package dev.dbos.transact.database.dao;
 
 import dev.dbos.transact.database.DbContext;
+import dev.dbos.transact.database.SystemDatabase;
+import dev.dbos.transact.database.SystemDatabase.NotificationRegistry;
+import dev.dbos.transact.database.signal.SignalKey;
+import dev.dbos.transact.database.signal.SignalMap;
 import dev.dbos.transact.json.SerializationUtil;
+import dev.dbos.transact.workflow.WorkflowStatus;
 import dev.dbos.transact.workflow.internal.StepResult;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -132,7 +138,13 @@ public class StreamsDAO {
         ctx, workflowId, functionId, key, STREAM_CLOSED_SENTINEL, "portable_json");
   }
 
-  public static Object readStream(DbContext ctx, String workflowId, String key, int offset)
+  public static Object readStream(
+      DbContext ctx,
+      String workflowId,
+      String key,
+      int offset,
+      Duration dbPollingInterval,
+      NotificationRegistry notificationRegistry)
       throws SQLException {
     String sql =
         """
@@ -142,23 +154,31 @@ public class StreamsDAO {
         """
             .formatted(ctx.schema());
 
-    try (Connection conn = ctx.getConnection();
-        var stmt = conn.prepareStatement(sql)) {
-      stmt.setString(1, workflowId);
-      stmt.setString(2, key);
-      stmt.setInt(3, offset);
-      try (var rs = stmt.executeQuery()) {
-        if (rs.next()) {
-          String value = rs.getString("value");
-          String serialization = rs.getString("serialization");
-          Object deserialized = SerializationUtil.deserializeValue(value, serialization, null);
-          if (STREAM_CLOSED_SENTINEL.equals(deserialized)) {
-            throw new IllegalStateException("Stream closed for key: " + key);
+    try (var sub = notificationRegistry.subscribe(new SignalKey.Stream(workflowId, key))) {
+      while (true) {
+        ctx.checkClosed();
+        try (Connection conn = ctx.getConnection();
+            var stmt = conn.prepareStatement(sql)) {
+          stmt.setString(1, workflowId);
+          stmt.setString(2, key);
+          stmt.setInt(3, offset);
+          try (var rs = stmt.executeQuery()) {
+            if (rs.next()) {
+              String value = rs.getString("value");
+              String serialization = rs.getString("serialization");
+              Object deserialized = SerializationUtil.deserializeValue(value, serialization, null);
+              if (STREAM_CLOSED_SENTINEL.equals(deserialized)) {
+                return SystemDatabase.END_OF_STREAM;
+              }
+              return deserialized;
+            }
           }
-          return deserialized;
         }
-        throw new IllegalArgumentException(
-            "No value found for workflow=" + workflowId + ", key=" + key + ", offset=" + offset);
+        WorkflowStatus status = WorkflowDAO.getWorkflowStatus(ctx, workflowId);
+        if (status == null || !status.status().isActive()) {
+          return SystemDatabase.END_OF_STREAM;
+        }
+        SignalMap.awaitAny(dbPollingInterval, sub);
       }
     }
   }

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StreamsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StreamsDAO.java
@@ -154,31 +154,51 @@ public class StreamsDAO {
         """
             .formatted(ctx.schema());
 
-    try (var sub = notificationRegistry.subscribe(new SignalKey.Stream(workflowId, key))) {
-      while (true) {
-        ctx.checkClosed();
-        try (Connection conn = ctx.getConnection();
-            var stmt = conn.prepareStatement(sql)) {
-          stmt.setString(1, workflowId);
-          stmt.setString(2, key);
-          stmt.setInt(3, offset);
-          try (var rs = stmt.executeQuery()) {
-            if (rs.next()) {
-              String value = rs.getString("value");
-              String serialization = rs.getString("serialization");
-              Object deserialized = SerializationUtil.deserializeValue(value, serialization, null);
-              if (STREAM_CLOSED_SENTINEL.equals(deserialized)) {
-                return SystemDatabase.END_OF_STREAM;
-              }
-              return deserialized;
+    while (true) {
+      ctx.checkClosed();
+      try (var sub = notificationRegistry.subscribe(new SignalKey.Stream(workflowId, key));
+          var conn = ctx.getConnection();
+          var stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setString(2, key);
+        stmt.setInt(3, offset);
+        try (var rs = stmt.executeQuery()) {
+          if (rs.next()) {
+            String value = rs.getString("value");
+            String serialization = rs.getString("serialization");
+            Object deserialized = SerializationUtil.deserializeValue(value, serialization, null);
+            if (STREAM_CLOSED_SENTINEL.equals(deserialized)) {
+              throw new IllegalStateException("Stream is closed: " + key);
             }
+            return deserialized;
           }
+        }
+        if (!streamKeyExists(conn, ctx.schema(), workflowId, key)) {
+          throw new IllegalArgumentException("Stream key not found: " + key);
         }
         WorkflowStatus status = WorkflowDAO.getWorkflowStatus(ctx, workflowId);
         if (status == null || !status.status().isActive()) {
           return SystemDatabase.END_OF_STREAM;
         }
         SignalMap.awaitAny(dbPollingInterval, sub);
+      }
+    }
+  }
+
+  private static boolean streamKeyExists(
+      Connection conn, String schema, String workflowId, String key) throws SQLException {
+    String sql =
+        """
+        SELECT 1 FROM "%s".streams
+        WHERE workflow_uuid = ? AND key = ?
+        LIMIT 1
+        """
+            .formatted(schema);
+    try (var stmt = conn.prepareStatement(sql)) {
+      stmt.setString(1, workflowId);
+      stmt.setString(2, key);
+      try (var rs = stmt.executeQuery()) {
+        return rs.next();
       }
     }
   }

--- a/transact/src/main/java/dev/dbos/transact/database/signal/SignalKey.java
+++ b/transact/src/main/java/dev/dbos/transact/database/signal/SignalKey.java
@@ -1,11 +1,16 @@
 package dev.dbos.transact.database.signal;
 
 public sealed interface SignalKey
-    permits SignalKey.Cancellation, SignalKey.Event, SignalKey.Message, SignalKey.Shutdown {
+    permits SignalKey.Cancellation,
+        SignalKey.Event,
+        SignalKey.Message,
+        SignalKey.Shutdown,
+        SignalKey.Stream {
 
   enum WakeReason {
     MESSAGE,
     EVENT,
+    STREAM,
     CANCELLED,
     SHUTDOWN,
     TIMEOUT
@@ -34,6 +39,12 @@ public sealed interface SignalKey
   record Shutdown() implements SignalKey {
     public WakeReason wakeReason() {
       return WakeReason.SHUTDOWN;
+    }
+  }
+
+  record Stream(String workflowId, String key) implements SignalKey {
+    public WakeReason wakeReason() {
+      return WakeReason.STREAM;
     }
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/client/StreamTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/StreamTest.java
@@ -6,12 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import dev.dbos.transact.DBOS;
+import dev.dbos.transact.StartWorkflowOptions;
 import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.context.WorkflowOptions;
 import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.StepInfo;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
@@ -205,5 +207,50 @@ public class StreamTest {
       Iterator<Object> iter = client.readStream("nonexistent", "mykey");
       assertFalse(iter.hasNext());
     }
+  }
+
+  @Test
+  public void streamTerminationWhileReaderBlockedTest() throws Exception {
+    var wfid = UUID.randomUUID().toString();
+    var handle =
+        dbos.startWorkflow(
+            () -> proxy.writeOneAndSleep("term_key"), new StartWorkflowOptions(wfid));
+
+    long start = System.currentTimeMillis();
+    var values = new ArrayList<>();
+    Iterator<Object> iter = dbos.readStream(wfid, "term_key");
+    while (iter.hasNext()) {
+      values.add(iter.next());
+    }
+    long elapsed = System.currentTimeMillis() - start;
+
+    handle.getResult();
+    assertEquals(List.of("only_value"), values);
+    assertTrue(elapsed < 10_000, "reader took " + elapsed + "ms to notice workflow termination");
+  }
+
+  @Test
+  public void streamLowLatencyDeliveryTest() throws Exception {
+    var wfid = UUID.randomUUID().toString();
+    int count = 3;
+    var handle =
+        dbos.startWorkflow(
+            () -> proxy.writeTimestampsAndClose("latency_key", count),
+            new StartWorkflowOptions(wfid));
+
+    long maxLatencyMs = 0;
+    int received = 0;
+    Iterator<Object> iter = dbos.readStream(wfid, "latency_key");
+    while (iter.hasNext()) {
+      long writtenAt = ((Number) iter.next()).longValue();
+      maxLatencyMs = Math.max(maxLatencyMs, System.currentTimeMillis() - writtenAt);
+      received++;
+    }
+
+    handle.getResult();
+    assertEquals(count, received);
+    assertTrue(
+        maxLatencyMs < 500,
+        "max delivery latency " + maxLatencyMs + "ms exceeds 500ms — LISTEN/NOTIFY not working");
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/client/StreamTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/StreamTest.java
@@ -13,6 +13,8 @@ import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.StepInfo;
 
+import org.junit.jupiter.api.Assumptions;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -231,6 +233,7 @@ public class StreamTest {
 
   @Test
   public void streamLowLatencyDeliveryTest() throws Exception {
+    Assumptions.assumeFalse(PgContainer.USE_COCKROACH_DB, "PG-only: LISTEN/NOTIFY not supported on CRDB");
     var wfid = UUID.randomUUID().toString();
     int count = 3;
     var handle =

--- a/transact/src/test/java/dev/dbos/transact/client/StreamTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/StreamTest.java
@@ -13,8 +13,6 @@ import dev.dbos.transact.utils.PgContainer;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.StepInfo;
 
-import org.junit.jupiter.api.Assumptions;
-
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -22,6 +20,7 @@ import java.util.UUID;
 
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.Assumptions;
 
 public class StreamTest {
 
@@ -233,7 +232,8 @@ public class StreamTest {
 
   @Test
   public void streamLowLatencyDeliveryTest() throws Exception {
-    Assumptions.assumeFalse(PgContainer.USE_COCKROACH_DB, "PG-only: LISTEN/NOTIFY not supported on CRDB");
+    Assumptions.assumeFalse(
+        PgContainer.USE_COCKROACH_DB, "PG-only: LISTEN/NOTIFY not supported on CRDB");
     var wfid = UUID.randomUUID().toString();
     int count = 3;
     var handle =

--- a/transact/src/test/java/dev/dbos/transact/client/StreamTestService.java
+++ b/transact/src/test/java/dev/dbos/transact/client/StreamTestService.java
@@ -4,6 +4,8 @@ import dev.dbos.transact.DBOS;
 import dev.dbos.transact.workflow.Workflow;
 import dev.dbos.transact.workflow.WorkflowClassName;
 
+import java.time.Duration;
+
 interface StreamTestService {
   void writeStreamBasic(String key, String value);
 
@@ -12,6 +14,10 @@ interface StreamTestService {
   String writeAndCloseStream(String key);
 
   void writeStreamInStep(String key, String value);
+
+  void writeOneAndSleep(String key);
+
+  void writeTimestampsAndClose(String key, int count);
 }
 
 @WorkflowClassName("StreamTestServiceImpl")
@@ -55,5 +61,22 @@ class StreamTestServiceImpl implements StreamTestService {
           dbos.writeStream(key, value);
         },
         "streamStep");
+  }
+
+  @Workflow
+  @Override
+  public void writeOneAndSleep(String key) {
+    dbos.writeStream(key, "only_value");
+    dbos.sleep(Duration.ofSeconds(2));
+  }
+
+  @Workflow
+  @Override
+  public void writeTimestampsAndClose(String key, int count) {
+    for (int i = 0; i < count; i++) {
+      dbos.writeStream(key, System.currentTimeMillis());
+      dbos.sleep(Duration.ofSeconds(1));
+    }
+    dbos.closeStream(key);
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -1030,7 +1030,7 @@ public class SystemDatabaseTest {
     sysdb.writeStreamFromWorkflow(workflowId, 1, "key1", "value1", "portable_json");
     sysdb.closeStream(workflowId, 2, "key1");
 
-    assertThrows(IllegalStateException.class, () -> sysdb.readStream(workflowId, "key1", 1));
+    assertEquals(SystemDatabase.END_OF_STREAM, sysdb.readStream(workflowId, "key1", 1));
   }
 
   @Test
@@ -1058,7 +1058,8 @@ public class SystemDatabaseTest {
     var status = WorkflowStatusInternalBuilder.create(workflowId).build();
     sysdb.initWorkflowStatus(status, 5, false, false);
 
-    assertThrows(IllegalArgumentException.class, () -> sysdb.readStream(workflowId, "key", 0));
+    DBUtils.setWorkflowState(dataSource, workflowId, WorkflowState.SUCCESS.name());
+    assertEquals(SystemDatabase.END_OF_STREAM, sysdb.readStream(workflowId, "key", 0));
   }
 
   public void testInsertWorkflowStatusValidation() throws Exception {


### PR DESCRIPTION
Replaces the 1-second Thread.sleep polling loop in StreamIterator with PostgreSQL LISTEN/NOTIFY, so stream readers wake immediately when a new value is inserted. The 1-second poll is retained as a fallback timeout and for use when LISTEN/NOTIFY is not available (like CRDB)

A previous PR added Migration 39 which adds the trigger that fires `pg_notify('dbos_streams_channel', workflow_uuid || '::' || key)` on every INSERT to the streams table. This PR wires up the reader side.

fixes #401 