### PR TITLE
catch getHostName exception

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/conductor/Conductor.java
+++ b/transact/src/main/java/dev/dbos/transact/conductor/Conductor.java
@@ -63,6 +63,20 @@ public class Conductor implements AutoCloseable {
 
   private static final Logger logger = LoggerFactory.getLogger(Conductor.class);
 
+  private static final String hostname = resolveHostname();
+
+  private static String resolveHostname() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (Exception e) {
+      return fallbackHostname(System.getenv("HOSTNAME"));
+    }
+  }
+
+  static String fallbackHostname(String envHostname) {
+    return envHostname != null ? envHostname : "<unknown>";
+  }
+
   private final String url;
   private final SystemDatabase systemDatabase;
   private final DBOSExecutor dbosExecutor;
@@ -741,7 +755,6 @@ public class Conductor implements AutoCloseable {
     return CompletableFuture.supplyAsync(
         () -> {
           try {
-            String hostname = InetAddress.getLocalHost().getHostName();
             return new ExecutorInfoResponse(
                 message,
                 conductor.dbosExecutor.executorId(),

--- a/transact/src/test/java/dev/dbos/transact/conductor/ConductorTest.java
+++ b/transact/src/test/java/dev/dbos/transact/conductor/ConductorTest.java
@@ -72,6 +72,7 @@ import org.java_websocket.framing.Framedata;
 import org.java_websocket.handshake.ClientHandshake;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -524,6 +525,16 @@ public class ConductorTest {
       assertNull(jsonNode.get("error_message"));
       assertEquals("{}", jsonNode.get("executor_metadata").toString());
     }
+  }
+
+  @Test
+  public void fallbackHostnameUsesEnvWhenSet() {
+    assertEquals("env-host", Conductor.fallbackHostname("env-host"));
+  }
+
+  @Test
+  public void fallbackHostnameUsesUnknownWhenNull() {
+    assertEquals("<unknown>", Conductor.fallbackHostname(null));
   }
 
   @RetryingTest(3)


### PR DESCRIPTION
In DBOS Cloud, InetAddress.getLocalHost().getHostName(); throws. Update the conductor code to fallback first to HOSTNAME env and then "<unknown>" if HOSTNAME not set