### PR TITLE
Fix concurrent applySchedules invocation

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -6,6 +6,7 @@ import dev.dbos.transact.database.dao.ApplicationVersionDAO;
 import dev.dbos.transact.database.dao.ExternalStateDAO;
 import dev.dbos.transact.database.dao.NotificationsDAO;
 import dev.dbos.transact.database.dao.QueuesDAO;
+import dev.dbos.transact.database.dao.ScheduleRecord;
 import dev.dbos.transact.database.dao.SchedulesDAO;
 import dev.dbos.transact.database.dao.StepsDAO;
 import dev.dbos.transact.database.dao.StreamsDAO;
@@ -610,6 +611,19 @@ public class SystemDatabase implements AutoCloseable {
       List<String> scheduleNamePrefixes) {
     return dbRetry(
         () -> SchedulesDAO.listSchedules(ctx, statuses, workflowNames, scheduleNamePrefixes));
+  }
+
+  // Raw form of listSchedules used by the scheduler's poller; see ScheduleRecord for why.
+  public List<ScheduleRecord> listScheduleRecords(
+      List<ScheduleStatus> statuses,
+      List<String> workflowNames,
+      List<String> scheduleNamePrefixes) {
+    return dbRetry(
+        () -> SchedulesDAO.listScheduleRecords(ctx, statuses, workflowNames, scheduleNamePrefixes));
+  }
+
+  public @Nullable DBOSSerializer serializer() {
+    return ctx.serializer();
   }
 
   public void pauseSchedule(String name) {

--- a/transact/src/main/java/dev/dbos/transact/database/dao/ScheduleRecord.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/ScheduleRecord.java
@@ -1,0 +1,53 @@
+package dev.dbos.transact.database.dao;
+
+import dev.dbos.transact.json.DBOSSerializer;
+import dev.dbos.transact.json.SerializationUtil;
+import dev.dbos.transact.workflow.ScheduleStatus;
+import dev.dbos.transact.workflow.WorkflowSchedule;
+
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+// Raw form of a schedule row as read from the database: context is kept as its serialized string
+// rather than deserialized. This lets callers that only need to detect definition changes (the
+// scheduler's poller) compare schedules without deserializing, and without depending on the
+// equals() of whatever type the deserialized context happens to be. Callers that need the actual
+// context object convert via toWorkflowSchedule().
+public record ScheduleRecord(
+    @Nullable String id,
+    @NonNull String scheduleName,
+    @NonNull String workflowName,
+    @NonNull String className,
+    @NonNull String cron,
+    @NonNull ScheduleStatus status,
+    @Nullable String context,
+    @Nullable Instant lastFiredAt,
+    boolean automaticBackfill,
+    @Nullable ZoneId cronTimezone,
+    @Nullable String queueName) {
+
+  public boolean isActive() {
+    return status == ScheduleStatus.ACTIVE;
+  }
+
+  public WorkflowSchedule toWorkflowSchedule(@Nullable DBOSSerializer serializer) {
+    Object deserializedContext =
+        SerializationUtil.deserializeValue(
+            context, serializer != null ? serializer.name() : null, serializer);
+    return new WorkflowSchedule(
+        id,
+        scheduleName,
+        workflowName,
+        className,
+        cron,
+        status,
+        deserializedContext,
+        lastFiredAt,
+        automaticBackfill,
+        cronTimezone,
+        queueName);
+  }
+}

--- a/transact/src/main/java/dev/dbos/transact/database/dao/SchedulesDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/SchedulesDAO.java
@@ -87,8 +87,21 @@ public class SchedulesDAO {
       List<String> workflowNames,
       List<String> scheduleNamePrefixes)
       throws SQLException {
+    return listScheduleRecords(ctx, statuses, workflowNames, scheduleNamePrefixes).stream()
+        .map(r -> r.toWorkflowSchedule(ctx.serializer()))
+        .toList();
+  }
 
-    DBOSSerializer serializer = ctx.serializer();
+  // Raw form of listSchedules: keeps context as its serialized string instead of deserializing it.
+  // Used by the scheduler's poller to detect definition changes without relying on the equals() of
+  // whatever type the deserialized context happens to be.
+  public static List<ScheduleRecord> listScheduleRecords(
+      DbContext ctx,
+      List<ScheduleStatus> statuses,
+      List<String> workflowNames,
+      List<String> scheduleNamePrefixes)
+      throws SQLException {
+
     StringBuilder sql =
         new StringBuilder(
             """
@@ -135,9 +148,9 @@ public class SchedulesDAO {
           }
         }
         try (ResultSet rs = ps.executeQuery()) {
-          List<WorkflowSchedule> results = new ArrayList<>();
+          List<ScheduleRecord> results = new ArrayList<>();
           while (rs.next()) {
-            results.add(rowToSchedule(rs, serializer));
+            results.add(rowToScheduleRecord(rs));
           }
           return results;
         }
@@ -151,7 +164,12 @@ public class SchedulesDAO {
 
   public static Optional<WorkflowSchedule> getSchedule(DbContext ctx, String name)
       throws SQLException {
-    DBOSSerializer serializer = ctx.serializer();
+    return getScheduleRecord(ctx, name).map(r -> r.toWorkflowSchedule(ctx.serializer()));
+  }
+
+  // Raw form of getSchedule: keeps context as its serialized string instead of deserializing it.
+  public static Optional<ScheduleRecord> getScheduleRecord(DbContext ctx, String name)
+      throws SQLException {
     String sql =
         """
         SELECT schedule_id, schedule_name, workflow_name, workflow_class_name,
@@ -167,7 +185,7 @@ public class SchedulesDAO {
       ps.setString(1, name);
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
-          return Optional.of(rowToSchedule(rs, serializer));
+          return Optional.of(rowToScheduleRecord(rs));
         }
         return Optional.empty();
       }
@@ -305,22 +323,18 @@ public class SchedulesDAO {
     }
   }
 
-  private static WorkflowSchedule rowToSchedule(ResultSet rs, DBOSSerializer serializer)
-      throws SQLException {
-    Object context =
-        SerializationUtil.deserializeValue(
-            rs.getString(7), serializer != null ? serializer.name() : null, serializer);
+  private static ScheduleRecord rowToScheduleRecord(ResultSet rs) throws SQLException {
     String lastFiredAtStr = rs.getString(8);
     String timeZoneStr = rs.getString(10);
 
-    return new WorkflowSchedule(
+    return new ScheduleRecord(
         rs.getString(1),
         rs.getString(2),
         rs.getString(3),
         rs.getString(4),
         rs.getString(5),
         ScheduleStatus.valueOf(rs.getString(6)),
-        context,
+        rs.getString(7),
         lastFiredAtStr != null ? Instant.parse(lastFiredAtStr) : null,
         rs.getBoolean(9),
         timeZoneStr != null ? ZoneId.of(timeZoneStr) : null,

--- a/transact/src/main/java/dev/dbos/transact/database/dao/SchedulesDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/SchedulesDAO.java
@@ -239,8 +239,7 @@ public class SchedulesDAO {
       conn.setAutoCommit(false);
       try {
         for (WorkflowSchedule schedule : schedules) {
-          deleteSchedule(conn, ctx.schema(), schedule.scheduleName());
-          createSchedule(
+          upsertSchedule(
               conn,
               ctx.schema(),
               ctx.serializer(),
@@ -254,6 +253,55 @@ public class SchedulesDAO {
         conn.rollback();
         throw e;
       }
+    }
+  }
+
+  // Idempotent upsert by schedule_name, so concurrent applySchedules calls for the same name
+  // can't race each other into a duplicate-key error. On conflict, schedule_id, status, and
+  // last_fired_at are preserved from the existing row; the poller detects the changed
+  // definition and restarts the schedule's future.
+  private static void upsertSchedule(
+      Connection conn, String schema, DBOSSerializer serializer, WorkflowSchedule schedule)
+      throws SQLException {
+
+    SchedulerService.CRON_PARSER.parse(schedule.cron());
+
+    String sql =
+        """
+        INSERT INTO "%s".workflow_schedules
+            (schedule_id, schedule_name, workflow_name, workflow_class_name,
+             schedule, status, context, last_fired_at, automatic_backfill,
+             cron_timezone, queue_name)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT (schedule_name) DO UPDATE SET
+            workflow_name = EXCLUDED.workflow_name,
+            workflow_class_name = EXCLUDED.workflow_class_name,
+            schedule = EXCLUDED.schedule,
+            context = EXCLUDED.context,
+            automatic_backfill = EXCLUDED.automatic_backfill,
+            cron_timezone = EXCLUDED.cron_timezone,
+            queue_name = EXCLUDED.queue_name
+        """
+            .formatted(schema);
+
+    var serializedContext =
+        SerializationUtil.serializeValue(
+            schedule.context(), serializer != null ? serializer.name() : null, serializer);
+
+    var timeZone = schedule.cronTimezone() == null ? null : schedule.cronTimezone().getId();
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setString(1, schedule.id() != null ? schedule.id() : UUID.randomUUID().toString());
+      ps.setString(2, schedule.scheduleName());
+      ps.setString(3, schedule.workflowName());
+      ps.setString(4, schedule.className());
+      ps.setString(5, schedule.cron());
+      ps.setString(6, schedule.status().name());
+      ps.setString(7, serializedContext.serializedValue());
+      ps.setString(8, schedule.lastFiredAt() != null ? schedule.lastFiredAt().toString() : null);
+      ps.setBoolean(9, schedule.automaticBackfill());
+      ps.setString(10, timeZone);
+      ps.setString(11, schedule.queueName());
+      ps.executeUpdate();
     }
   }
 

--- a/transact/src/main/java/dev/dbos/transact/database/dao/SchedulesDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/SchedulesDAO.java
@@ -42,7 +42,7 @@ public class SchedulesDAO {
     // language
     Objects.requireNonNull(schedule.status(), "status must not be null");
     Objects.requireNonNull(schedule.cron(), "cron must not be null");
-    SchedulerService.CRON_PARSER.parse(schedule.cron());
+    SchedulerService.CRON_PARSER.parse(schedule.cron()).validate();
 
     String sql =
         """
@@ -264,7 +264,7 @@ public class SchedulesDAO {
       Connection conn, String schema, DBOSSerializer serializer, WorkflowSchedule schedule)
       throws SQLException {
 
-    SchedulerService.CRON_PARSER.parse(schedule.cron());
+    SchedulerService.CRON_PARSER.parse(schedule.cron()).validate();
 
     String sql =
         """

--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -34,11 +34,10 @@ import org.slf4j.LoggerFactory;
 
 public class SchedulerService implements AutoCloseable {
 
-  // Tracks a running schedule: the definition fields are a snapshot used to detect definition
-  // changes, the future is the currently scheduled task which is replaced on every firing.
-  // Context is compared as its raw serialized string (from ScheduleRecord) rather than the
-  // deserialized value, since the deserialized value's class may not implement a meaningful
-  // equals().
+  // Tracks a running schedule: the definition fields are a snapshot of the schedule fields used to
+  // detect changes, the future is the currently scheduled task which is replaced on every firing.
+  // Context is compared as its raw serialized string since the deserialized value's class may not
+  // implement a meaningful equals().
   private record RunningSchedule(
       String workflowName,
       String className,
@@ -46,7 +45,10 @@ public class SchedulerService implements AutoCloseable {
       String context,
       ZoneId cronTimezone,
       String queueName,
-      AtomicReference<ScheduledFuture<?>> future) {
+      AtomicReference<ScheduledFuture<?>> future,
+      // Set by cancelWorkflowSchedule so a task that's already mid-execution won't reschedule
+      // itself after being removed from the map.
+      AtomicBoolean canceled) {
 
     RunningSchedule(ScheduleRecord record) {
       this(
@@ -56,7 +58,8 @@ public class SchedulerService implements AutoCloseable {
           record.context(),
           record.cronTimezone(),
           record.queueName(),
-          new AtomicReference<>());
+          new AtomicReference<>(),
+          new AtomicBoolean());
     }
 
     boolean matches(ScheduleRecord record) {
@@ -89,8 +92,7 @@ public class SchedulerService implements AutoCloseable {
   private final AtomicBoolean paused = new AtomicBoolean(false);
   private final ConcurrentHashMap<String, RunningSchedule> runningSchedules =
       new ConcurrentHashMap<>();
-  // Ensures the fast-path poll and the regular fixed-rate poll never run concurrently, which would
-  // otherwise race when scheduling new workflow futures.
+  // Ensure the fast-path poll and the regular fixed-rate poll never run concurrently
   private final ReentrantLock pollLock = new ReentrantLock();
 
   public SchedulerService(
@@ -265,15 +267,18 @@ public class SchedulerService implements AutoCloseable {
 
           // Returns true if a future was scheduled for the next execution, false if the cron
           // expression has no next execution (eg. a day-of-month/month combination that can
-          // never occur, like April 31st).
+          // never occur, like April 31st) or if the schedule was already canceled.
           public boolean schedule() {
+            if (running.canceled().get()) {
+              return false;
+            }
             return executionTime
                 .nextExecution(nextTime)
                 .map(
                     cronTime -> {
                       this.nextTime = cronTime.truncatedTo(ChronoUnit.SECONDS);
-                      var prevFuture =
-                          running.future().getAndSet(scheduleTask(this.nextTime, this));
+                      var newFuture = scheduleTask(this.nextTime, this);
+                      var prevFuture = running.future().getAndSet(newFuture);
                       // prevFuture should be null or a scheduled task that already fired.
                       // cancel it anyway just to be sure
                       if (prevFuture != null) {
@@ -283,6 +288,11 @@ public class SchedulerService implements AutoCloseable {
                               wfSchedule.scheduleName());
                         }
                         prevFuture.cancel(false);
+                      }
+                      // Cancel the future if the schedule has been cancelled since check at the top
+                      // of the schedule() method
+                      if (running.canceled().get() && newFuture != null) {
+                        newFuture.cancel(false);
                       }
                       return true;
                     })
@@ -294,6 +304,10 @@ public class SchedulerService implements AutoCloseable {
             // if execServiceRef is null, the scheduler service was shut down so don't start
             // the workflow or schedule the next execution
             if (execServiceRef.get() == null) {
+              return;
+            }
+            // Also don't execute or schedule next execution if the schedule is cancelled
+            if (running.canceled().get()) {
               return;
             }
 
@@ -360,6 +374,8 @@ public class SchedulerService implements AutoCloseable {
   private void cancelWorkflowSchedule(String scheduleId) {
     var running = runningSchedules.remove(scheduleId);
     if (running != null) {
+      // Set before reading future() so a task mid-execution sees it once it reschedules itself.
+      running.canceled().set(true);
       var future = running.future().get();
       if (future != null) {
         future.cancel(false);

--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -3,6 +3,7 @@ package dev.dbos.transact.execution;
 import dev.dbos.transact.Constants;
 import dev.dbos.transact.StartWorkflowOptions;
 import dev.dbos.transact.database.SystemDatabase;
+import dev.dbos.transact.database.dao.ScheduleRecord;
 import dev.dbos.transact.workflow.WorkflowSchedule;
 
 import java.time.Duration;
@@ -35,33 +36,36 @@ public class SchedulerService implements AutoCloseable {
 
   // Tracks a running schedule: the definition fields are a snapshot used to detect definition
   // changes, the future is the currently scheduled task which is replaced on every firing.
+  // Context is compared as its raw serialized string (from ScheduleRecord) rather than the
+  // deserialized value, since the deserialized value's class may not implement a meaningful
+  // equals().
   private record RunningSchedule(
       String workflowName,
       String className,
       String cron,
-      Object context,
+      String context,
       ZoneId cronTimezone,
       String queueName,
       AtomicReference<ScheduledFuture<?>> future) {
 
-    RunningSchedule(WorkflowSchedule schedule) {
+    RunningSchedule(ScheduleRecord record) {
       this(
-          schedule.workflowName(),
-          schedule.className(),
-          schedule.cron(),
-          schedule.context(),
-          schedule.cronTimezone(),
-          schedule.queueName(),
+          record.workflowName(),
+          record.className(),
+          record.cron(),
+          record.context(),
+          record.cronTimezone(),
+          record.queueName(),
           new AtomicReference<>());
     }
 
-    boolean matches(WorkflowSchedule schedule) {
-      return Objects.equals(workflowName, schedule.workflowName())
-          && Objects.equals(className, schedule.className())
-          && Objects.equals(cron, schedule.cron())
-          && Objects.equals(context, schedule.context())
-          && Objects.equals(cronTimezone, schedule.cronTimezone())
-          && Objects.equals(queueName, schedule.queueName());
+    boolean matches(ScheduleRecord record) {
+      return Objects.equals(workflowName, record.workflowName())
+          && Objects.equals(className, record.className())
+          && Objects.equals(cron, record.cron())
+          && Objects.equals(context, record.context())
+          && Objects.equals(cronTimezone, record.cronTimezone())
+          && Objects.equals(queueName, record.queueName());
     }
   }
 
@@ -152,7 +156,7 @@ public class SchedulerService implements AutoCloseable {
         return;
       }
 
-      var schedules = dbosExecutor.listSchedules(null, null, null);
+      var schedules = systemDatabase.listScheduleRecords(null, null, null);
       if (logger.isDebugEnabled()) {
         logger.debug("pollWorkflowSchedules found {} schedules", schedules.size());
         for (var s : schedules) {
@@ -162,7 +166,7 @@ public class SchedulerService implements AutoCloseable {
       }
 
       // shut down any running schedule that isn't in the list of current schedules
-      var currentIds = schedules.stream().map(WorkflowSchedule::id).collect(Collectors.toSet());
+      var currentIds = schedules.stream().map(ScheduleRecord::id).collect(Collectors.toSet());
       for (var key : runningSchedules.keySet()) {
         if (!currentIds.contains(key)) {
           cancelWorkflowSchedule(key);
@@ -200,14 +204,14 @@ public class SchedulerService implements AutoCloseable {
 
   // allowBackfill should be false when restarting an already-running schedule whose definition
   // changed; backfill only applies the first time a schedule starts firing.
-  private void startWorkflowSchedule(WorkflowSchedule schedule, boolean allowBackfill) {
+  private void startWorkflowSchedule(ScheduleRecord record, boolean allowBackfill) {
     var optRegWf =
-        dbosExecutor.getRegisteredWorkflow(schedule.workflowName(), schedule.className(), "");
+        dbosExecutor.getRegisteredWorkflow(record.workflowName(), record.className(), "");
     if (optRegWf.isEmpty()) {
       logger.error(
           "Workflow schedule {} has missing workflow function {}",
-          schedule.scheduleName(),
-          RegisteredWorkflow.fullyQualifiedName(schedule.workflowName(), schedule.className()));
+          record.scheduleName(),
+          RegisteredWorkflow.fullyQualifiedName(record.workflowName(), record.className()));
       return;
     }
 
@@ -215,38 +219,39 @@ public class SchedulerService implements AutoCloseable {
     if (!Arrays.equals(regWorkflow.workflowMethod().getParameterTypes(), EXPECTED_PARAMETERS)) {
       logger.error(
           "Workflow schedule {} workflow {} has invalid signature, signature must be (Instant, Object)",
-          schedule.scheduleName(),
+          record.scheduleName(),
           regWorkflow.fullyQualifiedName());
       return;
     }
 
     final String queueName =
-        Objects.requireNonNullElse(schedule.queueName(), Constants.DBOS_INTERNAL_QUEUE);
+        Objects.requireNonNullElse(record.queueName(), Constants.DBOS_INTERNAL_QUEUE);
     if (dbosExecutor.findQueue(queueName).isEmpty()) {
-      logger.error("Workflow schedule {} has invalid queue {}", schedule.scheduleName(), queueName);
+      logger.error("Workflow schedule {} has invalid queue {}", record.scheduleName(), queueName);
       return;
     }
 
     Cron cron;
     try {
-      cron = CRON_PARSER.parse(schedule.cron()).validate();
+      cron = CRON_PARSER.parse(record.cron()).validate();
     } catch (Exception e) {
       logger.error(
           "Workflow schedule {} has invalid cron expression {}",
-          schedule.scheduleName(),
-          schedule.cron(),
+          record.scheduleName(),
+          record.cron(),
           e);
       return;
     }
 
     if (allowBackfill
-        && schedule.automaticBackfill()
-        && schedule.lastFiredAt() != null
-        && schedule.lastFiredAt().isBefore(Instant.now())) {
-      dbosExecutor.backfillSchedule(schedule.scheduleName(), schedule.lastFiredAt(), Instant.now());
+        && record.automaticBackfill()
+        && record.lastFiredAt() != null
+        && record.lastFiredAt().isBefore(Instant.now())) {
+      dbosExecutor.backfillSchedule(record.scheduleName(), record.lastFiredAt(), Instant.now());
     }
 
-    var running = new RunningSchedule(schedule);
+    var running = new RunningSchedule(record);
+    var schedule = record.toWorkflowSchedule(systemDatabase.serializer());
 
     var task =
         new Runnable() {

--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -247,7 +247,6 @@ public class SchedulerService implements AutoCloseable {
     }
 
     var running = new RunningSchedule(schedule);
-    runningSchedules.put(schedule.id(), running);
 
     var task =
         new Runnable() {
@@ -259,10 +258,13 @@ public class SchedulerService implements AutoCloseable {
 
           ZonedDateTime nextTime = ZonedDateTime.now(timeZone);
 
-          public void schedule() {
-            executionTime
+          // Returns true if a future was scheduled for the next execution, false if the cron
+          // expression has no next execution (eg. a day-of-month/month combination that can
+          // never occur, like April 31st).
+          public boolean schedule() {
+            return executionTime
                 .nextExecution(nextTime)
-                .ifPresent(
+                .map(
                     cronTime -> {
                       this.nextTime = cronTime.truncatedTo(ChronoUnit.SECONDS);
                       var prevFuture =
@@ -277,7 +279,9 @@ public class SchedulerService implements AutoCloseable {
                         }
                         prevFuture.cancel(false);
                       }
-                    });
+                      return true;
+                    })
+                .orElse(false);
           }
 
           @Override
@@ -320,7 +324,14 @@ public class SchedulerService implements AutoCloseable {
           }
         };
 
-    task.schedule();
+    if (task.schedule()) {
+      runningSchedules.put(schedule.id(), running);
+    } else {
+      logger.error(
+          "Workflow schedule {} cron expression {} has no upcoming execution; not starting",
+          schedule.scheduleName(),
+          schedule.cron());
+    }
   }
 
   private ScheduledFuture<?> scheduleTask(ZonedDateTime nextTime, Runnable task) {

--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -33,6 +33,38 @@ import org.slf4j.LoggerFactory;
 
 public class SchedulerService implements AutoCloseable {
 
+  // Tracks a running schedule: the definition fields are a snapshot used to detect definition
+  // changes, the future is the currently scheduled task which is replaced on every firing.
+  private record RunningSchedule(
+      String workflowName,
+      String className,
+      String cron,
+      Object context,
+      ZoneId cronTimezone,
+      String queueName,
+      AtomicReference<ScheduledFuture<?>> future) {
+
+    RunningSchedule(WorkflowSchedule schedule) {
+      this(
+          schedule.workflowName(),
+          schedule.className(),
+          schedule.cron(),
+          schedule.context(),
+          schedule.cronTimezone(),
+          schedule.queueName(),
+          new AtomicReference<>());
+    }
+
+    boolean matches(WorkflowSchedule schedule) {
+      return Objects.equals(workflowName, schedule.workflowName())
+          && Objects.equals(className, schedule.className())
+          && Objects.equals(cron, schedule.cron())
+          && Objects.equals(context, schedule.context())
+          && Objects.equals(cronTimezone, schedule.cronTimezone())
+          && Objects.equals(queueName, schedule.queueName());
+    }
+  }
+
   private static final Logger logger = LoggerFactory.getLogger(SchedulerService.class);
 
   public static final CronParser CRON_PARSER =
@@ -51,7 +83,7 @@ public class SchedulerService implements AutoCloseable {
   private final Duration pollingInterval;
   private final AtomicReference<ScheduledExecutorService> execServiceRef = new AtomicReference<>();
   private final AtomicBoolean paused = new AtomicBoolean(false);
-  private final ConcurrentHashMap<String, ScheduledFuture<?>> workflowScheduleFutures =
+  private final ConcurrentHashMap<String, RunningSchedule> runningSchedules =
       new ConcurrentHashMap<>();
   // Ensures the fast-path poll and the regular fixed-rate poll never run concurrently, which would
   // otherwise race when scheduling new workflow futures.
@@ -110,8 +142,7 @@ public class SchedulerService implements AutoCloseable {
   }
 
   private void pollWorkflowSchedules() {
-    // Skip if another poll (fast-path or regular) is already running rather than queueing behind
-    // it.
+    // Skip if another poll (fast-path or regular) is already running
     if (!pollLock.tryLock()) {
       return;
     }
@@ -130,148 +161,32 @@ public class SchedulerService implements AutoCloseable {
         }
       }
 
-      // shut down any scheduled future that isn't in the list of current schedules
+      // shut down any running schedule that isn't in the list of current schedules
       var currentIds = schedules.stream().map(WorkflowSchedule::id).collect(Collectors.toSet());
-      for (var key : workflowScheduleFutures.keySet()) {
+      for (var key : runningSchedules.keySet()) {
         if (!currentIds.contains(key)) {
           cancelWorkflowSchedule(key);
         }
       }
 
       for (var schedule : schedules) {
-        var scheduleRunning = workflowScheduleFutures.containsKey(schedule.id());
+        var running = runningSchedules.get(schedule.id());
         if (!schedule.isActive()) {
-          // if the schedule is no longer active but we still have a scheduled future for it, cancel
-          // it
-          if (scheduleRunning) {
+          // if the schedule is no longer active, cancel any running future we have for it
+          if (running != null) {
             cancelWorkflowSchedule(schedule.id());
           }
-        } else if (!scheduleRunning) {
-          // if the schedule is active but we don't yet have a scheduled future for it, schedule it
-          // now
-          var optRegWf =
-              dbosExecutor.getRegisteredWorkflow(schedule.workflowName(), schedule.className(), "");
-          if (optRegWf.isEmpty()) {
-            logger.error(
-                "Workflow schedule {} has missing workflow function {}",
-                schedule.scheduleName(),
-                RegisteredWorkflow.fullyQualifiedName(
-                    schedule.workflowName(), schedule.className()));
-            continue;
+        } else if (running != null) {
+          // already running: applySchedules upserts in place, so a changed definition doesn't
+          // change schedule.id(). Detect the change and restart with the new definition; no
+          // backfill needed since the schedule was already running.
+          if (!running.matches(schedule)) {
+            cancelWorkflowSchedule(schedule.id());
+            startWorkflowSchedule(schedule, false);
           }
-
-          var regWorkflow = optRegWf.orElseThrow();
-          if (!Arrays.equals(
-              regWorkflow.workflowMethod().getParameterTypes(), EXPECTED_PARAMETERS)) {
-            logger.error(
-                "Workflow schedule {} workflow {} has invalid signature, signature must be (Instant, Object)",
-                schedule.scheduleName(),
-                regWorkflow.fullyQualifiedName());
-            continue;
-          }
-
-          final String queueName =
-              Objects.requireNonNullElse(schedule.queueName(), Constants.DBOS_INTERNAL_QUEUE);
-          if (dbosExecutor.findQueue(queueName).isEmpty()) {
-            logger.error(
-                "Workflow schedule {} has invalid queue {}", schedule.scheduleName(), queueName);
-            continue;
-          }
-
-          Cron cron;
-          try {
-            cron = CRON_PARSER.parse(schedule.cron()).validate();
-          } catch (Exception e) {
-            logger.error(
-                "Workflow schedule {} has invalid cron expression {}",
-                schedule.scheduleName(),
-                schedule.cron(),
-                e);
-            continue;
-          }
-
-          if (schedule.automaticBackfill()
-              && schedule.lastFiredAt() != null
-              && schedule.lastFiredAt().isBefore(Instant.now())) {
-            dbosExecutor.backfillSchedule(
-                schedule.scheduleName(), schedule.lastFiredAt(), Instant.now());
-          }
-
-          var task =
-              new Runnable() {
-
-                final ZoneId timeZone =
-                    Objects.requireNonNullElseGet(
-                        schedule.cronTimezone(), () -> ZoneId.systemDefault());
-                final WorkflowSchedule wfSchedule = schedule;
-                final ExecutionTime executionTime = ExecutionTime.forCron(cron);
-
-                ZonedDateTime nextTime = ZonedDateTime.now(timeZone);
-
-                public void schedule() {
-                  executionTime
-                      .nextExecution(nextTime)
-                      .ifPresent(
-                          cronTime -> {
-                            this.nextTime = cronTime.truncatedTo(ChronoUnit.SECONDS);
-                            var prevFuture =
-                                workflowScheduleFutures.put(
-                                    wfSchedule.id(), scheduleTask(this.nextTime, this));
-                            // prevFuture should be null or a scheduled task that already fired.
-                            // cancel it anyway just to be sure
-                            if (prevFuture != null) {
-                              if (!prevFuture.isDone()) {
-                                logger.debug(
-                                    "Previous scheduled task for {} has not yet completed",
-                                    wfSchedule.scheduleName());
-                              }
-                              prevFuture.cancel(false);
-                            }
-                          });
-                }
-
-                @Override
-                public void run() {
-                  // if execServiceRef is null, the scheduler service was shut down so don't start
-                  // the workflow or schedule the next execution
-                  if (execServiceRef.get() == null) {
-                    return;
-                  }
-
-                  try {
-                    if (paused.get()) {
-                      logger.debug(
-                          "Skipping scheduled workflow {} schedule {} because scheduler is paused",
-                          regWorkflow.fullyQualifiedName(),
-                          wfSchedule.scheduleName());
-                      return;
-                    }
-                    var args = new Object[] {nextTime.toInstant(), wfSchedule.context()};
-                    var workflowId =
-                        "sched-%s-%s"
-                            .formatted(wfSchedule.scheduleName(), nextTime.toOffsetDateTime());
-                    logger.debug(
-                        "Queuing scheduled workflow {} schedule {} workflowId {}",
-                        regWorkflow.fullyQualifiedName(),
-                        wfSchedule.scheduleName(),
-                        workflowId);
-                    var appVersion = dbosExecutor.getLatestApplicationVersion().versionName();
-                    var options =
-                        new StartWorkflowOptions(workflowId)
-                            .withQueue(queueName)
-                            .withAppVersion(appVersion);
-                    dbosExecutor.startRegisteredWorkflow(regWorkflow, args, options);
-                    systemDatabase.updateScheduleLastFiredAt(
-                        wfSchedule.scheduleName(), nextTime.toInstant());
-                  } catch (Exception e) {
-                    logger.error("Scheduled task {} exception", schedule.scheduleName(), e);
-                  } finally {
-                    schedule();
-                  }
-                }
-              };
-
-          task.schedule();
+        } else {
+          // if schedule is active but we don't have a running future for it, schedule it now
+          startWorkflowSchedule(schedule, true);
         }
       }
     } catch (Exception e) {
@@ -281,6 +196,131 @@ public class SchedulerService implements AutoCloseable {
     } finally {
       pollLock.unlock();
     }
+  }
+
+  // allowBackfill should be false when restarting an already-running schedule whose definition
+  // changed; backfill only applies the first time a schedule starts firing.
+  private void startWorkflowSchedule(WorkflowSchedule schedule, boolean allowBackfill) {
+    var optRegWf =
+        dbosExecutor.getRegisteredWorkflow(schedule.workflowName(), schedule.className(), "");
+    if (optRegWf.isEmpty()) {
+      logger.error(
+          "Workflow schedule {} has missing workflow function {}",
+          schedule.scheduleName(),
+          RegisteredWorkflow.fullyQualifiedName(schedule.workflowName(), schedule.className()));
+      return;
+    }
+
+    var regWorkflow = optRegWf.orElseThrow();
+    if (!Arrays.equals(regWorkflow.workflowMethod().getParameterTypes(), EXPECTED_PARAMETERS)) {
+      logger.error(
+          "Workflow schedule {} workflow {} has invalid signature, signature must be (Instant, Object)",
+          schedule.scheduleName(),
+          regWorkflow.fullyQualifiedName());
+      return;
+    }
+
+    final String queueName =
+        Objects.requireNonNullElse(schedule.queueName(), Constants.DBOS_INTERNAL_QUEUE);
+    if (dbosExecutor.findQueue(queueName).isEmpty()) {
+      logger.error("Workflow schedule {} has invalid queue {}", schedule.scheduleName(), queueName);
+      return;
+    }
+
+    Cron cron;
+    try {
+      cron = CRON_PARSER.parse(schedule.cron()).validate();
+    } catch (Exception e) {
+      logger.error(
+          "Workflow schedule {} has invalid cron expression {}",
+          schedule.scheduleName(),
+          schedule.cron(),
+          e);
+      return;
+    }
+
+    if (allowBackfill
+        && schedule.automaticBackfill()
+        && schedule.lastFiredAt() != null
+        && schedule.lastFiredAt().isBefore(Instant.now())) {
+      dbosExecutor.backfillSchedule(schedule.scheduleName(), schedule.lastFiredAt(), Instant.now());
+    }
+
+    var running = new RunningSchedule(schedule);
+    runningSchedules.put(schedule.id(), running);
+
+    var task =
+        new Runnable() {
+
+          final ZoneId timeZone =
+              Objects.requireNonNullElseGet(schedule.cronTimezone(), () -> ZoneId.systemDefault());
+          final WorkflowSchedule wfSchedule = schedule;
+          final ExecutionTime executionTime = ExecutionTime.forCron(cron);
+
+          ZonedDateTime nextTime = ZonedDateTime.now(timeZone);
+
+          public void schedule() {
+            executionTime
+                .nextExecution(nextTime)
+                .ifPresent(
+                    cronTime -> {
+                      this.nextTime = cronTime.truncatedTo(ChronoUnit.SECONDS);
+                      var prevFuture =
+                          running.future().getAndSet(scheduleTask(this.nextTime, this));
+                      // prevFuture should be null or a scheduled task that already fired.
+                      // cancel it anyway just to be sure
+                      if (prevFuture != null) {
+                        if (!prevFuture.isDone()) {
+                          logger.debug(
+                              "Previous scheduled task for {} has not yet completed",
+                              wfSchedule.scheduleName());
+                        }
+                        prevFuture.cancel(false);
+                      }
+                    });
+          }
+
+          @Override
+          public void run() {
+            // if execServiceRef is null, the scheduler service was shut down so don't start
+            // the workflow or schedule the next execution
+            if (execServiceRef.get() == null) {
+              return;
+            }
+
+            try {
+              if (paused.get()) {
+                logger.debug(
+                    "Skipping scheduled workflow {} schedule {} because scheduler is paused",
+                    regWorkflow.fullyQualifiedName(),
+                    wfSchedule.scheduleName());
+                return;
+              }
+              var args = new Object[] {nextTime.toInstant(), wfSchedule.context()};
+              var workflowId =
+                  "sched-%s-%s".formatted(wfSchedule.scheduleName(), nextTime.toOffsetDateTime());
+              logger.debug(
+                  "Queuing scheduled workflow {} schedule {} workflowId {}",
+                  regWorkflow.fullyQualifiedName(),
+                  wfSchedule.scheduleName(),
+                  workflowId);
+              var appVersion = dbosExecutor.getLatestApplicationVersion().versionName();
+              var options =
+                  new StartWorkflowOptions(workflowId)
+                      .withQueue(queueName)
+                      .withAppVersion(appVersion);
+              dbosExecutor.startRegisteredWorkflow(regWorkflow, args, options);
+              systemDatabase.updateScheduleLastFiredAt(
+                  wfSchedule.scheduleName(), nextTime.toInstant());
+            } catch (Exception e) {
+              logger.error("Scheduled task {} exception", schedule.scheduleName(), e);
+            } finally {
+              schedule();
+            }
+          }
+        };
+
+    task.schedule();
   }
 
   private ScheduledFuture<?> scheduleTask(ZonedDateTime nextTime, Runnable task) {
@@ -302,9 +342,12 @@ public class SchedulerService implements AutoCloseable {
   }
 
   private void cancelWorkflowSchedule(String scheduleId) {
-    var future = workflowScheduleFutures.remove(scheduleId);
-    if (future != null) {
-      future.cancel(false);
+    var running = runningSchedules.remove(scheduleId);
+    if (running != null) {
+      var future = running.future().get();
+      if (future != null) {
+        future.cancel(false);
+      }
     }
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/client/ClientScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/ClientScheduleTest.java
@@ -183,7 +183,7 @@ public class ClientScheduleTest {
       var replaced = client.getSchedule("apply-1").orElseThrow();
       assertEquals("0/10 * * * * *", replaced.cron());
       assertNotNull(replaced.id());
-      assertNotEquals(originalId, replaced.id()); // new UUID assigned
+      assertEquals(originalId, replaced.id()); // schedule_id preserved across upsert
       assertNull(replaced.lastFiredAt());
       var created = client.getSchedule("apply-2").orElseThrow();
       assertNotNull(created.id());

--- a/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
@@ -309,6 +309,10 @@ class WorkflowScheduleTest {
       }
     } finally {
       executor.shutdown();
+      if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
+        executor.shutdownNow();
+        fail("executor did not terminate promptly");
+      }
     }
 
     var schedules = dbos.listSchedules(null, null, null);

--- a/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
@@ -247,11 +247,120 @@ class WorkflowScheduleTest {
     var replaced = dbos.getSchedule("apply-1").orElseThrow();
     assertEquals("0/10 * * * * *", replaced.cron());
     assertNotNull(replaced.id());
-    assertNotEquals(originalId, replaced.id()); // new UUID assigned
+    assertEquals(originalId, replaced.id()); // schedule_id preserved across upsert
     assertNull(replaced.lastFiredAt());
     var created = dbos.getSchedule("apply-2").orElseThrow();
     assertNotNull(created.id());
     assertNull(created.lastFiredAt());
+  }
+
+  @Test
+  public void applySchedulesPreservesRuntimeState() {
+    // A re-apply replaces the definition but must not clobber runtime state (status,
+    // last_fired_at, schedule_id).
+    registerAndLaunch();
+
+    dbos.applySchedules(
+        new WorkflowSchedule("state-keep", workflowName(), className(), "0 0 0 1 1 *")
+            .withContext("v1"));
+    var originalId = dbos.getSchedule("state-keep").orElseThrow().id();
+    dbos.pauseSchedule("state-keep");
+    DBOSTestAccess.getSystemDatabase(dbos)
+        .updateScheduleLastFiredAt("state-keep", Instant.parse("2020-01-01T00:00:00Z"));
+
+    dbos.applySchedules(
+        new WorkflowSchedule("state-keep", workflowName(), className(), "0 0 0 1 1 *")
+            .withContext("v2"));
+
+    var sched = dbos.getSchedule("state-keep").orElseThrow();
+    assertEquals(originalId, sched.id()); // preserved
+    assertEquals(ScheduleStatus.PAUSED, sched.status()); // preserved
+    assertEquals(Instant.parse("2020-01-01T00:00:00Z"), sched.lastFiredAt()); // preserved
+    assertEquals("v2", sched.context()); // definition still updated
+  }
+
+  @Test
+  public void applySchedulesConcurrent() throws Exception {
+    // Concurrent applies of the same schedule must be idempotent: one row, no error.
+    registerAndLaunch();
+
+    int numWorkers = 8;
+    var barrier = new java.util.concurrent.CyclicBarrier(numWorkers);
+    var executor = java.util.concurrent.Executors.newFixedThreadPool(numWorkers);
+    try {
+      var futures = new java.util.ArrayList<java.util.concurrent.Future<?>>();
+      for (int i = 0; i < numWorkers; i++) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  try {
+                    barrier.await(30, TimeUnit.SECONDS);
+                  } catch (Exception e) {
+                    throw new RuntimeException(e);
+                  }
+                  dbos.applySchedules(
+                      new WorkflowSchedule(
+                              "shared-schedule", workflowName(), className(), "* * * * * *")
+                          .withContext("us"));
+                }));
+      }
+      for (var f : futures) {
+        f.get(30, TimeUnit.SECONDS); // surface any exception raised by a worker
+      }
+    } finally {
+      executor.shutdown();
+    }
+
+    var schedules = dbos.listSchedules(null, null, null);
+    assertEquals(1, schedules.size());
+    assertEquals("shared-schedule", schedules.get(0).scheduleName());
+    assertEquals("* * * * * *", schedules.get(0).cron());
+    assertEquals("us", schedules.get(0).context());
+    var scheduleId = schedules.get(0).id();
+
+    // Re-applying leaves one row, updated in place, preserving schedule_id.
+    dbos.applySchedules(
+        new WorkflowSchedule("shared-schedule", workflowName(), className(), "0 0 * * * *")
+            .withContext("eu"));
+    schedules = dbos.listSchedules(null, null, null);
+    assertEquals(1, schedules.size());
+    assertEquals(scheduleId, schedules.get(0).id());
+    assertEquals("0 0 * * * *", schedules.get(0).cron());
+    assertEquals("eu", schedules.get(0).context());
+  }
+
+  @Test
+  public void applySchedulesLiveUpdate() throws Exception {
+    // Re-applying a changed schedule must take effect live: the poller detects the modified
+    // definition and restarts the schedule's future with the new context, preserving schedule_id.
+    var impl = registerAndLaunch();
+
+    dbos.applySchedules(
+        new WorkflowSchedule("live-update", workflowName(), className(), "* * * * * *")
+            .withContext("v1"));
+
+    waitUntil(() -> "v1".equals(impl.lastContext), Duration.ofSeconds(10));
+
+    // Re-apply the same schedule with a new context.
+    impl.reset();
+    dbos.applySchedules(
+        new WorkflowSchedule("live-update", workflowName(), className(), "* * * * * *")
+            .withContext("v2"));
+
+    // The running poller must pick up the new context and fire it.
+    waitUntil(() -> "v2".equals(impl.lastContext), Duration.ofSeconds(10));
+  }
+
+  private static void waitUntil(java.util.function.BooleanSupplier condition, Duration timeout)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + timeout.toMillis();
+    while (System.currentTimeMillis() < deadline) {
+      if (condition.getAsBoolean()) {
+        return;
+      }
+      Thread.sleep(100);
+    }
+    assertTrue(condition.getAsBoolean(), "condition not met within " + timeout);
   }
 
   @Test


### PR DESCRIPTION
Port of https://github.com/dbos-inc/dbos-transact-py/pull/741 to Java.

# Problem

SchedulesDAO.applySchedules implemented "create or replace" as DELETE followed by INSERT (with a freshly generated schedule_id every time). Two concurrent applySchedules calls for the same schedule name could interleave their delete/insert pairs and collide on the schedule_name unique constraint. The new schedule_id on every apply also meant a schedule's identity churned on every edit.

# Fix
- SchedulesDAO: replaced delete+insert with a single INSERT ... ON CONFLICT (schedule_name) DO UPDATE, making applySchedules idempotent and race-free. On conflict, schedule_id, status, and last_fired_at are preserved from the existing row; only the definition fields (workflow name/class, cron, context, backfill flag, timezone, queue) are updated.
- SchedulerService: since schedule_id no longer changes on re-apply, the poller can no longer rely on a new ID to detect an edited schedule. Added RunningSchedule, a record snapshotting each running schedule's definition fields (excluding identity/status/runtime state) plus its current ScheduledFuture, keyed by schedule id in a single map (runningSchedules). Each poll compares the live schedule against the snapshot via RunningSchedule.matches(...); on a mismatch, the schedule's future is cancelled and restarted with the new definition (no backfill on restart — only on first start).