### PR TITLE
Conductor Updates

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/admin/ListQueuedWorkflowsRequest.java
+++ b/transact/src/main/java/dev/dbos/transact/admin/ListQueuedWorkflowsRequest.java
@@ -53,7 +53,8 @@ public record ListQueuedWorkflowsRequest(
         null, // completedAfter
         null, // completedBefore
         null, // dequeuedAfter
-        null // dequeuedBefore
+        null, // dequeuedBefore
+        null // scheduleName
         );
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/admin/ListWorkflowsRequest.java
+++ b/transact/src/main/java/dev/dbos/transact/admin/ListWorkflowsRequest.java
@@ -61,6 +61,7 @@ public record ListWorkflowsRequest(
         completed_after != null ? Instant.parse(completed_after) : null,
         completed_before != null ? Instant.parse(completed_before) : null,
         dequeued_after != null ? Instant.parse(dequeued_after) : null,
-        dequeued_before != null ? Instant.parse(dequeued_before) : null);
+        dequeued_before != null ? Instant.parse(dequeued_before) : null,
+        null); // scheduleName
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/conductor/protocol/GetWorkflowAggregatesRequest.java
+++ b/transact/src/main/java/dev/dbos/transact/conductor/protocol/GetWorkflowAggregatesRequest.java
@@ -5,6 +5,7 @@ import dev.dbos.transact.workflow.GetWorkflowAggregatesInput;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -40,6 +41,7 @@ public class GetWorkflowAggregatesRequest extends BaseMessage {
     public List<String> executor_id;
     public List<String> queue_name;
     public List<String> workflow_id_prefix;
+    public Map<String, Object> attributes;
   }
 
   public GetWorkflowAggregatesInput toInput() {
@@ -75,6 +77,7 @@ public class GetWorkflowAggregatesRequest extends BaseMessage {
         body.completed_after != null ? Instant.parse(body.completed_after) : null,
         body.completed_before != null ? Instant.parse(body.completed_before) : null,
         body.dequeued_after != null ? Instant.parse(body.dequeued_after) : null,
-        body.dequeued_before != null ? Instant.parse(body.dequeued_before) : null);
+        body.dequeued_before != null ? Instant.parse(body.dequeued_before) : null,
+        body.attributes);
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/conductor/protocol/GetWorkflowRequest.java
+++ b/transact/src/main/java/dev/dbos/transact/conductor/protocol/GetWorkflowRequest.java
@@ -45,7 +45,8 @@ public class GetWorkflowRequest extends BaseMessage {
         null, // completedAfter
         null, // completedBefore
         null, // dequeuedAfter
-        null // dequeuedBefore
+        null, // dequeuedBefore
+        null // scheduleName
         );
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/conductor/protocol/ListQueuedWorkflowsRequest.java
+++ b/transact/src/main/java/dev/dbos/transact/conductor/protocol/ListQueuedWorkflowsRequest.java
@@ -27,6 +27,10 @@ public class ListQueuedWorkflowsRequest extends BaseMessage {
 
     public String start_time;
     public String end_time;
+    public String completed_after;
+    public String completed_before;
+    public String dequeued_after;
+    public String dequeued_before;
 
     @JsonDeserialize(using = StringOrListDeserializer.class)
     public List<String> status;
@@ -88,10 +92,10 @@ public class ListQueuedWorkflowsRequest extends BaseMessage {
         body.was_forked_from,
         body.has_parent,
         body.attributes,
-        null, // completedAfter
-        null, // completedBefore
-        null, // dequeuedAfter
-        null // dequeuedBefore
-        );
+        body.completed_after != null ? Instant.parse(body.completed_after) : null,
+        body.completed_before != null ? Instant.parse(body.completed_before) : null,
+        body.dequeued_after != null ? Instant.parse(body.dequeued_after) : null,
+        body.dequeued_before != null ? Instant.parse(body.dequeued_before) : null,
+        null); // scheduleName
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/conductor/protocol/ListWorkflowsRequest.java
+++ b/transact/src/main/java/dev/dbos/transact/conductor/protocol/ListWorkflowsRequest.java
@@ -52,6 +52,9 @@ public class ListWorkflowsRequest extends BaseMessage {
     @JsonDeserialize(using = StringOrListDeserializer.class)
     public List<String> executor_id;
 
+    @JsonDeserialize(using = StringOrListDeserializer.class)
+    public List<String> schedule_name;
+
     public Integer limit;
     public Integer offset;
     public Boolean sort_desc;
@@ -93,6 +96,7 @@ public class ListWorkflowsRequest extends BaseMessage {
         body.completed_after != null ? Instant.parse(body.completed_after) : null,
         body.completed_before != null ? Instant.parse(body.completed_before) : null,
         body.dequeued_after != null ? Instant.parse(body.dequeued_after) : null,
-        body.dequeued_before != null ? Instant.parse(body.dequeued_before) : null);
+        body.dequeued_before != null ? Instant.parse(body.dequeued_before) : null,
+        body.schedule_name);
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/conductor/protocol/WorkflowsOutput.java
+++ b/transact/src/main/java/dev/dbos/transact/conductor/protocol/WorkflowsOutput.java
@@ -37,6 +37,7 @@ public class WorkflowsOutput {
   public String DelayUntilEpochMS;
   public String CompletedAt;
   public String Attributes;
+  public String ScheduleName;
 
   public WorkflowsOutput(WorkflowStatus status) {
     Object[] input = status.input();
@@ -82,5 +83,6 @@ public class WorkflowsOutput {
         status.completedAt() == null ? null : String.valueOf(status.completedAtEpochMs());
     // JSON rather than toString() so the wire format is parseable by Conductor
     this.Attributes = status.attributes() != null ? JsonUtility.toJson(status.attributes()) : null;
+    this.ScheduleName = status.scheduleName();
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
@@ -76,7 +76,7 @@ public class WorkflowDAO {
         authenticated_user, assumed_role, authenticated_roles,
         created_at, updated_at, completed_at, started_at_epoch_ms,
         recovery_attempts, workflow_timeout_ms, workflow_deadline_epoch_ms,
-        forked_from, parent_workflow_id, was_forked_from, attributes
+        forked_from, parent_workflow_id, was_forked_from, attributes, schedule_name
       """;
 
   private WorkflowDAO() {}
@@ -213,8 +213,8 @@ public class WorkflowDAO {
             executor_id, application_version, application_id,
             created_at, updated_at, recovery_attempts,
             workflow_timeout_ms, workflow_deadline_epoch_ms,
-            parent_workflow_id, owner_xid, serialization, attributes
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb)
+            parent_workflow_id, owner_xid, serialization, attributes, schedule_name
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, ?)
           ON CONFLICT (workflow_uuid)
             DO UPDATE SET
               recovery_attempts = CASE
@@ -282,7 +282,8 @@ public class WorkflowDAO {
       stmt.setObject(24, ownerXid);
       stmt.setString(25, status.serialization());
       stmt.setString(26, attributesJson);
-      stmt.setInt(27, incrementAttempts ? 1 : 0);
+      stmt.setString(27, status.scheduleName());
+      stmt.setInt(28, incrementAttempts ? 1 : 0);
 
       try (ResultSet rs = stmt.executeQuery()) {
         if (rs.next()) {
@@ -686,6 +687,10 @@ public class WorkflowDAO {
       whereConditions.add("forked_from = ANY(?)");
       parameters.add(input.forkedFrom());
     }
+    if (input.scheduleName() != null && !input.scheduleName().isEmpty()) {
+      whereConditions.add("schedule_name = ANY(?)");
+      parameters.add(input.scheduleName());
+    }
     if (input.parentWorkflowId() != null && !input.parentWorkflowId().isEmpty()) {
       whereConditions.add("parent_workflow_id = ANY(?)");
       parameters.add(input.parentWorkflowId());
@@ -931,6 +936,12 @@ public class WorkflowDAO {
         parameters.add(prefix + "%");
       }
       whereConditions.add(prefixOr.toString());
+    }
+    if (input.attributes() != null && !input.attributes().isEmpty()) {
+      // Containment (@>) is served by the GIN index on the attributes column and matches
+      // workflows whose attributes contain all the given key-value pairs.
+      whereConditions.add("attributes @> ?::jsonb");
+      parameters.add(JsonUtility.toJson(input.attributes()));
     }
 
     if (whereConditions.length() > 0) {
@@ -1190,7 +1201,8 @@ public class WorkflowDAO {
             serialization,
             (attributesJson != null)
                 ? JsonUtility.fromJson(attributesJson, new TypeReference<Map<String, Object>>() {})
-                : null);
+                : null,
+            rs.getString("schedule_name"));
     return info;
   }
 

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -941,6 +941,7 @@ public class DBOSExecutor implements AutoCloseable {
           schedule.context(),
           schedule.queueName(),
           next.toInstant(),
+          schedule.scheduleName(),
           systemDatabase,
           serializer);
 
@@ -979,6 +980,7 @@ public class DBOSExecutor implements AutoCloseable {
         schedule.context(),
         schedule.queueName(),
         now,
+        schedule.scheduleName(),
         systemDatabase,
         serializer);
     return workflowId;
@@ -991,6 +993,7 @@ public class DBOSExecutor implements AutoCloseable {
       Object context,
       String queueName,
       @NonNull Instant scheduledAt,
+      String scheduleName,
       SystemDatabase systemDatabase,
       DBOSSerializer serializer) {
     var latestAppVersion = systemDatabase.getLatestApplicationVersion().versionName();
@@ -998,7 +1001,10 @@ public class DBOSExecutor implements AutoCloseable {
     var args = new Object[] {Objects.requireNonNull(scheduledAt), context};
 
     var options =
-        new ExecutionOptions(workflowId).withQueueName(queueName).withAppVersion(latestAppVersion);
+        new ExecutionOptions(workflowId)
+            .withQueueName(queueName)
+            .withAppVersion(latestAppVersion)
+            .withScheduleName(scheduleName);
     enqueueWorkflow(
         workflowName,
         className,
@@ -1447,6 +1453,16 @@ public class DBOSExecutor implements AutoCloseable {
   // start a registered workflow, separated out so it can be used by event listeners
   public <T, E extends Exception> WorkflowHandle<T, E> startRegisteredWorkflow(
       RegisteredWorkflow workflow, Object[] args, StartWorkflowOptions options) {
+    return startRegisteredWorkflow(workflow, args, options, null);
+  }
+
+  // overload used by SchedulerService: scheduleName is set only for schedule-triggered
+  // executions, never by user-facing StartWorkflowOptions.
+  <T, E extends Exception> WorkflowHandle<T, E> startRegisteredWorkflow(
+      RegisteredWorkflow workflow,
+      Object[] args,
+      StartWorkflowOptions options,
+      String scheduleName) {
     var ctx = DBOSContextHolder.get();
     var parent = getParent(ctx);
     var childWorkflowId =
@@ -1484,7 +1500,8 @@ public class DBOSExecutor implements AutoCloseable {
             .withAttributes(
                 options != null && options.attributes() != null
                     ? options.attributes()
-                    : ctx.resolveNextAttributes());
+                    : ctx.resolveNextAttributes())
+            .withScheduleName(scheduleName);
     return executeWorkflow(workflow, args, execOptions, parent);
   }
 
@@ -1940,7 +1957,8 @@ public class DBOSExecutor implements AutoCloseable {
             effectiveDeadline,
             parentWorkflow != null ? parentWorkflow.workflowId() : null,
             actualSerialization,
-            options.attributes());
+            options.attributes(),
+            options.scheduleName());
 
     WorkflowInitResult[] initResult = {null};
     initResult[0] =
@@ -2015,6 +2033,7 @@ public class DBOSExecutor implements AutoCloseable {
             null,
             null,
             serializedArgs.serialization(),
+            null,
             null);
     systemDatabase.recordErrorForUnstartedWorkflow(initStatus, serializedError.serializedValue());
   }

--- a/transact/src/main/java/dev/dbos/transact/execution/ExecutionOptions.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/ExecutionOptions.java
@@ -32,7 +32,9 @@ public record ExecutionOptions(
     Map<String, Object> attributes,
     // True when re-executing a workflow that previously crashed; skips re-enqueue guards.
     boolean isRecoveryRequest,
-    boolean isDequeuedRequest) {
+    boolean isDequeuedRequest,
+    // Name of the schedule that triggered this workflow, if any. Set only by the scheduler.
+    String scheduleName) {
   public ExecutionOptions {
     if (nullableIsEmpty(workflowId)) {
       throw new IllegalArgumentException("workflowId must not be empty");
@@ -96,7 +98,8 @@ public record ExecutionOptions(
         null,
         null,
         false,
-        false);
+        false,
+        null);
   }
 
   public ExecutionOptions(String workflowId) {
@@ -116,7 +119,8 @@ public record ExecutionOptions(
         null,
         null,
         false,
-        false);
+        false,
+        null);
   }
 
   public ExecutionOptions(String workflowId, Duration timeout, Instant deadline) {
@@ -136,7 +140,8 @@ public record ExecutionOptions(
         null,
         null,
         false,
-        false);
+        false,
+        null);
   }
 
   public ExecutionOptions asRecoveryRequest() {
@@ -156,7 +161,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         true,
-        false);
+        false,
+        this.scheduleName);
   }
 
   public ExecutionOptions asDequeuedRequest(String queueName, String partitionKey) {
@@ -176,7 +182,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         false,
-        true);
+        true,
+        this.scheduleName);
   }
 
   public ExecutionOptions withOptions(DBOSClient.EnqueueOptions options) {
@@ -196,7 +203,8 @@ public record ExecutionOptions(
         options.authenticatedRoles(),
         options.attributes(),
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withOptions(StartWorkflowOptions options) {
@@ -219,7 +227,8 @@ public record ExecutionOptions(
         options.authenticatedRoles(),
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withSerialization(String serialization) {
@@ -239,7 +248,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withPriority(Integer priority) {
@@ -259,7 +269,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withAppVersion(String appVersion) {
@@ -279,7 +290,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withAuthenticatedUser(String authenticatedUser) {
@@ -299,7 +311,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withAssumedRole(String assumedRole) {
@@ -319,7 +332,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withAuthenticatedRoles(List<String> authenticatedRoles) {
@@ -339,7 +353,8 @@ public record ExecutionOptions(
         authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withAttributes(Map<String, Object> attributes) {
@@ -359,7 +374,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withQueueName(String queueName) {
@@ -379,7 +395,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withTimeout(Duration timeout) {
@@ -399,7 +416,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withTimeout(Timeout timeout) {
@@ -419,7 +437,8 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
   }
 
   public ExecutionOptions withDeadline(Instant deadline) {
@@ -439,7 +458,29 @@ public record ExecutionOptions(
         this.authenticatedRoles,
         this.attributes,
         this.isRecoveryRequest,
-        this.isDequeuedRequest);
+        this.isDequeuedRequest,
+        this.scheduleName);
+  }
+
+  public ExecutionOptions withScheduleName(String scheduleName) {
+    return new ExecutionOptions(
+        this.workflowId,
+        this.timeout,
+        this.deadline,
+        this.queueName,
+        this.deduplicationId,
+        this.priority,
+        this.queuePartitionKey,
+        this.delay,
+        this.appVersion,
+        this.serialization,
+        this.authenticatedUser,
+        this.assumedRole,
+        this.authenticatedRoles,
+        this.attributes,
+        this.isRecoveryRequest,
+        this.isDequeuedRequest,
+        scheduleName);
   }
 
   public Duration timeoutDuration() {

--- a/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/SchedulerService.java
@@ -332,7 +332,8 @@ public class SchedulerService implements AutoCloseable {
                   new StartWorkflowOptions(workflowId)
                       .withQueue(queueName)
                       .withAppVersion(appVersion);
-              dbosExecutor.startRegisteredWorkflow(regWorkflow, args, options);
+              dbosExecutor.startRegisteredWorkflow(
+                  regWorkflow, args, options, wfSchedule.scheduleName());
               systemDatabase.updateScheduleLastFiredAt(
                   wfSchedule.scheduleName(), nextTime.toInstant());
             } catch (Exception e) {

--- a/transact/src/main/java/dev/dbos/transact/migrations/MigrationManager.java
+++ b/transact/src/main/java/dev/dbos/transact/migrations/MigrationManager.java
@@ -442,7 +442,8 @@ public class MigrationManager {
             migration37(isCockroach),
             migration38(isCockroach),
             migration39(useListenNotify),
-            MIGRATION_40);
+            MIGRATION_40,
+            MIGRATION_41);
     return migrations.stream().map(m -> m.formatted(schema)).toList();
   }
 
@@ -1095,5 +1096,13 @@ public class MigrationManager {
       """
       ALTER TABLE "%1$s"."workflow_status" ADD COLUMN IF NOT EXISTS "attributes" JSONB;
       CREATE INDEX IF NOT EXISTS "idx_workflow_status_attributes" ON "%1$s"."workflow_status" USING GIN ("attributes") WHERE "attributes" IS NOT NULL;
+      """;
+
+  // ADD COLUMN with no default is catalog-only; the partial index covers zero rows, so no
+  // CONCURRENTLY is needed. Tracks which schedule (if any) triggered a workflow instance.
+  static final String MIGRATION_41 =
+      """
+      ALTER TABLE "%1$s"."workflow_status" ADD COLUMN IF NOT EXISTS "schedule_name" TEXT;
+      CREATE INDEX IF NOT EXISTS "idx_workflow_status_schedule_name" ON "%1$s"."workflow_status" ("schedule_name") WHERE "schedule_name" IS NOT NULL;
       """;
 }

--- a/transact/src/main/java/dev/dbos/transact/workflow/GetWorkflowAggregatesInput.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/GetWorkflowAggregatesInput.java
@@ -1,9 +1,12 @@
 package dev.dbos.transact.workflow;
 
+import static dev.dbos.transact.internal.Validation.validateAttributes;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Input for {@code getWorkflowAggregates}.
@@ -45,19 +48,21 @@ public record GetWorkflowAggregatesInput(
     Instant completedAfter,
     Instant completedBefore,
     Instant dequeuedAfter,
-    Instant dequeuedBefore) {
+    Instant dequeuedBefore,
+    Map<String, Object> attributes) {
 
   public GetWorkflowAggregatesInput {
     if (timeBucketSize != null && (timeBucketSize.isNegative() || timeBucketSize.isZero())) {
       throw new IllegalArgumentException("timeBucketSize must be > 0");
     }
+    attributes = validateAttributes(attributes);
   }
 
   /** Constructs a default input with {@code selectCount=true} and no group-by or filter flags. */
   public GetWorkflowAggregatesInput() {
     this(
         false, false, false, false, false, true, false, false, false, null, null, null, null, null,
-        null, null, null, null, null, null, null, null);
+        null, null, null, null, null, null, null, null, null);
   }
 
   public GetWorkflowAggregatesInput withGroupByStatus(boolean groupByStatus) {
@@ -83,7 +88,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withGroupByName(boolean groupByName) {
@@ -109,7 +115,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withGroupByQueueName(boolean groupByQueueName) {
@@ -135,7 +142,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withGroupByExecutorId(boolean groupByExecutorId) {
@@ -161,7 +169,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withGroupByApplicationVersion(
@@ -188,7 +197,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withSelectCount(boolean selectCount) {
@@ -214,7 +224,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withSelectMinCreatedAt(boolean selectMinCreatedAt) {
@@ -240,7 +251,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withSelectMaxQueueWait(boolean selectMaxQueueWait) {
@@ -266,7 +278,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withSelectMaxTotalLatency(boolean selectMaxTotalLatency) {
@@ -292,7 +305,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withTimeBucketSize(Duration timeBucketSize) {
@@ -318,7 +332,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withWorkflowName(List<String> workflowName) {
@@ -344,7 +359,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withStatus(List<String> status) {
@@ -370,7 +386,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withStatus(String... status) {
@@ -400,7 +417,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withExecutorIds(List<String> executorIds) {
@@ -426,7 +444,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withApplicationVersion(List<String> applicationVersion) {
@@ -452,7 +471,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withWorkflowIdPrefix(List<String> workflowIdPrefix) {
@@ -478,7 +498,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withStartTime(Instant startTime) {
@@ -504,7 +525,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withEndTime(Instant endTime) {
@@ -530,7 +552,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withCompletedAfter(Instant completedAfter) {
@@ -556,7 +579,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withCompletedBefore(Instant completedBefore) {
@@ -582,7 +606,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withDequeuedAfter(Instant dequeuedAfter) {
@@ -608,7 +633,8 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
   }
 
   public GetWorkflowAggregatesInput withDequeuedBefore(Instant dequeuedBefore) {
@@ -634,6 +660,34 @@ public record GetWorkflowAggregatesInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        attributes);
+  }
+
+  public GetWorkflowAggregatesInput withAttributes(Map<String, Object> attributes) {
+    return new GetWorkflowAggregatesInput(
+        groupByStatus,
+        groupByName,
+        groupByQueueName,
+        groupByExecutorId,
+        groupByApplicationVersion,
+        selectCount,
+        selectMinCreatedAt,
+        selectMaxQueueWait,
+        selectMaxTotalLatency,
+        timeBucketSize,
+        workflowName,
+        status,
+        queueName,
+        executorIds,
+        applicationVersion,
+        workflowIdPrefix,
+        startTime,
+        endTime,
+        completedAfter,
+        completedBefore,
+        dequeuedAfter,
+        dequeuedBefore,
+        attributes);
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/workflow/ListWorkflowsInput.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/ListWorkflowsInput.java
@@ -39,7 +39,8 @@ public record ListWorkflowsInput(
     Instant completedAfter,
     Instant completedBefore,
     Instant dequeuedAfter,
-    Instant dequeuedBefore) {
+    Instant dequeuedBefore,
+    List<String> scheduleName) {
 
   // Validate the attributes filter here (every convenience constructor, withX copy, and the
   // conductor/admin asInput() paths route through this canonical constructor) so an invalid filter
@@ -51,7 +52,7 @@ public record ListWorkflowsInput(
   public ListWorkflowsInput() {
     this(
         null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
-        null, null, null, null, null, null, null, null, null, null, null, null);
+        null, null, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public ListWorkflowsInput(String workflowId) {
@@ -61,6 +62,7 @@ public record ListWorkflowsInput(
   public ListWorkflowsInput(List<String> workflowIds) {
     this(
         workflowIds,
+        null,
         null,
         null,
         null,
@@ -118,7 +120,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withStatus(List<WorkflowState> status) {
@@ -149,7 +152,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withStartTime(Instant startTime) {
@@ -180,7 +184,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withEndTime(Instant endTime) {
@@ -211,7 +216,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withWorkflowName(List<String> workflowName) {
@@ -242,7 +248,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withClassName(String className) {
@@ -273,7 +280,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withInstanceName(String instanceName) {
@@ -304,7 +312,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withApplicationVersion(List<String> applicationVersion) {
@@ -335,7 +344,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withAuthenticatedUser(List<String> authenticatedUser) {
@@ -366,7 +376,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withLimit(Integer limit) {
@@ -397,7 +408,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withOffset(Integer offset) {
@@ -428,7 +440,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withSortDesc(Boolean sortDesc) {
@@ -459,7 +472,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withWorkflowIdPrefix(List<String> workflowIdPrefix) {
@@ -490,7 +504,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withLoadInput(Boolean loadInput) {
@@ -521,7 +536,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withLoadOutput(Boolean loadOutput) {
@@ -552,7 +568,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withQueueName(List<String> queueName) {
@@ -583,7 +600,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withQueuesOnly(Boolean queuesOnly) {
@@ -614,7 +632,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withExecutorIds(List<String> executorIds) {
@@ -645,7 +664,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withForkedFrom(List<String> forkedFrom) {
@@ -676,7 +696,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withParentWorkflowId(List<String> parentWorkflowId) {
@@ -707,7 +728,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withWasForkedFrom(Boolean wasForkedFrom) {
@@ -738,7 +760,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withHasParent(Boolean hasParent) {
@@ -769,7 +792,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withAttributes(Map<String, Object> attributes) {
@@ -800,7 +824,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withCompletedAfter(Instant completedAfter) {
@@ -831,7 +856,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withCompletedBefore(Instant completedBefore) {
@@ -862,7 +888,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withDequeuedAfter(Instant dequeuedAfter) {
@@ -893,7 +920,8 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
   }
 
   public ListWorkflowsInput withDequeuedBefore(Instant dequeuedBefore) {
@@ -924,7 +952,40 @@ public record ListWorkflowsInput(
         completedAfter,
         completedBefore,
         dequeuedAfter,
-        dequeuedBefore);
+        dequeuedBefore,
+        scheduleName);
+  }
+
+  public ListWorkflowsInput withScheduleName(List<String> scheduleName) {
+    return new ListWorkflowsInput(
+        workflowIds,
+        status,
+        startTime,
+        endTime,
+        workflowName,
+        className,
+        instanceName,
+        applicationVersion,
+        authenticatedUser,
+        limit,
+        offset,
+        sortDesc,
+        workflowIdPrefix,
+        loadInput,
+        loadOutput,
+        queueName,
+        queuesOnly,
+        executorIds,
+        forkedFrom,
+        parentWorkflowId,
+        wasForkedFrom,
+        hasParent,
+        attributes,
+        completedAfter,
+        completedBefore,
+        dequeuedAfter,
+        dequeuedBefore,
+        scheduleName);
   }
 
   // Single value overloads for list parameters
@@ -966,5 +1027,9 @@ public record ListWorkflowsInput(
 
   public ListWorkflowsInput withParentWorkflowId(String parentWorkflowId) {
     return withParentWorkflowId(List.of(parentWorkflowId));
+  }
+
+  public ListWorkflowsInput withScheduleName(String scheduleName) {
+    return withScheduleName(List.of(scheduleName));
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/workflow/WorkflowStatus.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/WorkflowStatus.java
@@ -73,7 +73,9 @@ public record WorkflowStatus(
     /** Serialized representation of the workflow. */
     String serialization,
     /** Custom JSON-serializable key-value attributes attached to the workflow at creation. */
-    Map<String, Object> attributes) {
+    Map<String, Object> attributes,
+    /** Name of the schedule that triggered this workflow, if any. */
+    String scheduleName) {
 
   @JsonIgnore
   public Long timeoutMs() {
@@ -155,7 +157,8 @@ public record WorkflowStatus(
         && java.util.Objects.equals(delayUntil, that.delayUntil)
         && java.util.Objects.equals(completedAt, that.completedAt)
         && java.util.Objects.equals(serialization, that.serialization)
-        && java.util.Objects.equals(attributes, that.attributes);
+        && java.util.Objects.equals(attributes, that.attributes)
+        && java.util.Objects.equals(scheduleName, that.scheduleName);
   }
 
   /**
@@ -197,6 +200,7 @@ public record WorkflowStatus(
         delayUntil,
         completedAt,
         serialization,
-        attributes);
+        attributes,
+        scheduleName);
   }
 }

--- a/transact/src/main/java/dev/dbos/transact/workflow/internal/WorkflowStatusInternal.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/internal/WorkflowStatusInternal.java
@@ -32,7 +32,9 @@ public record WorkflowStatusInternal(
     String parentWorkflowId,
     String serialization,
     /** Custom JSON-serializable key-value attributes attached to the workflow at creation. */
-    Map<String, Object> attributes) {
+    Map<String, Object> attributes,
+    /** Name of the schedule that triggered this workflow, if any. Set only by the scheduler. */
+    String scheduleName) {
 
   public WorkflowStatusInternal {
     if (nullableIsEmpty(workflowId)) {

--- a/transact/src/test/java/dev/dbos/transact/conductor/ConductorTest.java
+++ b/transact/src/test/java/dev/dbos/transact/conductor/ConductorTest.java
@@ -1623,6 +1623,72 @@ public class ConductorTest {
   }
 
   @RetryingTest(3)
+  public void canListQueuedWorkflowsWithCompletedAndDequeuedFilters() throws Exception {
+    MessageListener listener = new MessageListener();
+    testServer.setListener(listener);
+    when(mockExec.listWorkflows(any())).thenReturn(List.of());
+
+    try (Conductor conductor = builder.build()) {
+      conductor.start();
+      assertTrue(listener.openLatch.await(5, TimeUnit.SECONDS), "open latch timed out");
+
+      Map<String, Object> body =
+          Map.of(
+              "completed_after", "2024-06-01T00:00:00Z",
+              "completed_before", "2024-06-02T00:00:00Z",
+              "dequeued_after", "2024-06-01T01:00:00Z",
+              "dequeued_before", "2024-06-01T23:00:00Z");
+      listener.send(MessageType.LIST_QUEUED_WORKFLOWS, "12345", Map.of("body", body));
+
+      assertTrue(listener.messageLatch.await(1, TimeUnit.SECONDS), "message latch timed out");
+      ArgumentCaptor<ListWorkflowsInput> inputCaptor =
+          ArgumentCaptor.forClass(ListWorkflowsInput.class);
+      verify(mockExec).listWorkflows(inputCaptor.capture());
+      ListWorkflowsInput input = inputCaptor.getValue();
+      assertEquals(
+          OffsetDateTime.parse("2024-06-01T00:00:00Z").toInstant(), input.completedAfter());
+      assertEquals(
+          OffsetDateTime.parse("2024-06-02T00:00:00Z").toInstant(), input.completedBefore());
+      assertEquals(OffsetDateTime.parse("2024-06-01T01:00:00Z").toInstant(), input.dequeuedAfter());
+      assertEquals(
+          OffsetDateTime.parse("2024-06-01T23:00:00Z").toInstant(), input.dequeuedBefore());
+    }
+  }
+
+  @RetryingTest(3)
+  public void canListWorkflowsWithScheduleNameFilter() throws Exception {
+    MessageListener listener = new MessageListener();
+    testServer.setListener(listener);
+    WorkflowStatus status =
+        new WorkflowStatusBuilder("wf-sched-1")
+            .status(WorkflowState.SUCCESS)
+            .workflowName("WF1")
+            .scheduleName("my-schedule")
+            .build();
+    when(mockExec.listWorkflows(any())).thenReturn(List.of(status));
+
+    try (Conductor conductor = builder.build()) {
+      conductor.start();
+      assertTrue(listener.openLatch.await(5, TimeUnit.SECONDS), "open latch timed out");
+
+      Map<String, Object> body = Map.of("schedule_name", "my-schedule");
+      listener.send(MessageType.LIST_WORKFLOWS, "12345", Map.of("body", body));
+
+      assertTrue(listener.messageLatch.await(1, TimeUnit.SECONDS), "message latch timed out");
+      ArgumentCaptor<ListWorkflowsInput> inputCaptor =
+          ArgumentCaptor.forClass(ListWorkflowsInput.class);
+      verify(mockExec).listWorkflows(inputCaptor.capture());
+      ListWorkflowsInput input = inputCaptor.getValue();
+      assertEquals(List.of("my-schedule"), input.scheduleName());
+
+      JsonNode jsonNode = mapper.readTree(listener.message);
+      JsonNode outputNode = jsonNode.get("output");
+      assertEquals(1, outputNode.size());
+      assertEquals("my-schedule", outputNode.get(0).get("ScheduleName").stringValue());
+    }
+  }
+
+  @RetryingTest(3)
   public void canGetWorkflow() throws Exception {
     MessageListener listener = new MessageListener();
     testServer.setListener(listener);
@@ -3319,6 +3385,38 @@ public class ConductorTest {
       assertEquals(1_700_000_000_000L, out.get(0).get("min_created_at").asLong());
       assertEquals(50L, out.get(0).get("max_queue_wait_ms").asLong());
       assertEquals(200L, out.get(0).get("max_total_latency_ms").asLong());
+    }
+  }
+
+  @RetryingTest(3)
+  public void canGetWorkflowAggregatesWithAttributes() throws Exception {
+    MessageListener listener = new MessageListener();
+    testServer.setListener(listener);
+
+    List<WorkflowAggregateRow> rows =
+        List.of(new WorkflowAggregateRow(Map.of("status", "SUCCESS"), 1L, null, null, null));
+    when(mockDB.getWorkflowAggregates(any(GetWorkflowAggregatesInput.class))).thenReturn(rows);
+
+    try (Conductor conductor = builder.build()) {
+      conductor.start();
+      assertTrue(listener.openLatch.await(5, TimeUnit.SECONDS), "open latch timed out");
+
+      listener.send(
+          MessageType.GET_WORKFLOW_AGGREGATES,
+          "req-agg-attrs",
+          Map.of(
+              "body", Map.of("group_by_status", true, "attributes", Map.of("team", "payments"))));
+      assertTrue(listener.messageLatch.await(1, TimeUnit.SECONDS), "message latch timed out");
+
+      ArgumentCaptor<GetWorkflowAggregatesInput> inputCaptor =
+          ArgumentCaptor.forClass(GetWorkflowAggregatesInput.class);
+      verify(mockDB).getWorkflowAggregates(inputCaptor.capture());
+      GetWorkflowAggregatesInput captured = inputCaptor.getValue();
+      assertEquals(Map.of("team", "payments"), captured.attributes());
+
+      JsonNode json = mapper.readTree(listener.message);
+      assertEquals("get_workflow_aggregates", json.get("type").stringValue());
+      assertNull(json.get("error_message"));
     }
   }
 

--- a/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/SystemDatabaseTest.java
@@ -1565,6 +1565,42 @@ public class SystemDatabaseTest {
   }
 
   @Test
+  public void testGetWorkflowAggregatesWithAttributesFilter() throws Exception {
+    // importWorkflow doesn't carry attributes, so insert directly via initWorkflowStatus.
+    sysdb.initWorkflowStatus(
+        WorkflowStatusInternalBuilder.create("agg-attr-wf-1")
+            .workflowName("WorkflowA")
+            .attributes(Map.of("team", "payments"))
+            .build(),
+        5,
+        false,
+        false);
+    sysdb.initWorkflowStatus(
+        WorkflowStatusInternalBuilder.create("agg-attr-wf-2")
+            .workflowName("WorkflowA")
+            .attributes(Map.of("team", "growth"))
+            .build(),
+        5,
+        false,
+        false);
+    sysdb.initWorkflowStatus(
+        WorkflowStatusInternalBuilder.create("agg-attr-wf-3").workflowName("WorkflowA").build(),
+        5,
+        false,
+        false);
+
+    var input =
+        new GetWorkflowAggregatesInput()
+            .withGroupByName(true)
+            .withAttributes(Map.of("team", "payments"));
+    var rows = sysdb.getWorkflowAggregates(input);
+
+    assertEquals(1, rows.size());
+    assertEquals("WorkflowA", rows.get(0).group().get("name"));
+    assertEquals(1, rows.get(0).count());
+  }
+
+  @Test
   public void testGetWorkflowAggregatesIdPrefix() throws Exception {
     sysdb.importWorkflow(
         List.of(

--- a/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
+++ b/transact/src/test/java/dev/dbos/transact/scheduled/WorkflowScheduleTest.java
@@ -530,6 +530,26 @@ class WorkflowScheduleTest {
     assertThrows(IllegalStateException.class, () -> dbos.triggerSchedule("no-such-sched"));
   }
 
+  @Test
+  public void triggerScheduleSetsScheduleName() throws Exception {
+    var impl = registerAndLaunch();
+
+    dbos.createSchedule(
+        new WorkflowSchedule("trigger-name-sched", workflowName(), className(), "0 0 0 1 1 *"));
+
+    impl.reset();
+    var handle = dbos.<Void, RuntimeException>triggerSchedule("trigger-name-sched");
+    handle.getResult();
+
+    var status = dbos.listWorkflows(new ListWorkflowsInput(handle.workflowId())).get(0);
+    assertEquals("trigger-name-sched", status.scheduleName());
+
+    // Filterable by scheduleName
+    var filtered =
+        dbos.listWorkflows(new ListWorkflowsInput().withScheduleName("trigger-name-sched"));
+    assertTrue(filtered.stream().anyMatch(w -> w.workflowId().equals(handle.workflowId())));
+  }
+
   // ── backfillSchedule ──────────────────────────────────────────────────────
 
   @Test
@@ -566,6 +586,25 @@ class WorkflowScheduleTest {
     var t = Instant.now().truncatedTo(ChronoUnit.SECONDS);
     var handles = dbos.backfillSchedule("backfill-empty", t, t);
     assertEquals(0, handles.size());
+  }
+
+  @Test
+  public void backfillScheduleSetsScheduleName() throws Exception {
+    var impl = registerAndLaunch();
+
+    dbos.createSchedule(
+        new WorkflowSchedule("backfill-name-sched", workflowName(), className(), "0 * * * * *"));
+
+    var start = Instant.parse("2024-01-01T10:00:30Z");
+    var end = Instant.parse("2024-01-01T10:01:30Z");
+
+    impl.reset();
+    var handles = dbos.backfillSchedule("backfill-name-sched", start, end);
+    assertEquals(1, handles.size());
+    handles.get(0).getResult();
+
+    var status = handles.get(0).getStatus();
+    assertEquals("backfill-name-sched", status.scheduleName());
   }
 
   @Test
@@ -779,5 +818,23 @@ class WorkflowScheduleTest {
     assertTrue(
         impl.latch.await(15, TimeUnit.SECONDS),
         "Expected latch to count down to zero within 15 seconds");
+  }
+
+  @Test
+  public void liveScheduleFiringSetsScheduleName() throws Exception {
+    var impl = registerAndLaunch();
+
+    dbos.createSchedule(
+        new WorkflowSchedule("live-name-sched", "latchedRun", className(), "0/1 * * * * *"));
+
+    assertTrue(impl.latch.await(15, TimeUnit.SECONDS));
+
+    var workflows =
+        dbos.listWorkflows(new ListWorkflowsInput().withScheduleName("live-name-sched"));
+    assertFalse(workflows.isEmpty());
+    for (var wf : workflows) {
+      assertEquals("live-name-sched", wf.scheduleName());
+      assertTrue(wf.workflowId().startsWith("sched-live-name-sched-"));
+    }
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/utils/WorkflowStatusBuilder.java
+++ b/transact/src/test/java/dev/dbos/transact/utils/WorkflowStatusBuilder.java
@@ -47,6 +47,7 @@ public class WorkflowStatusBuilder {
   private Instant delayUntil;
   private Instant completedAt;
   private String serialization;
+  private String scheduleName;
 
   public WorkflowStatus build() {
     return new WorkflowStatus(
@@ -80,7 +81,8 @@ public class WorkflowStatusBuilder {
         delayUntil,
         completedAt,
         serialization,
-        null);
+        null,
+        scheduleName);
   }
 
   public WorkflowStatusBuilder(String workflowId) {
@@ -234,6 +236,11 @@ public class WorkflowStatusBuilder {
 
   public WorkflowStatusBuilder serialization(String serialization) {
     this.serialization = serialization;
+    return this;
+  }
+
+  public WorkflowStatusBuilder scheduleName(String scheduleName) {
+    this.scheduleName = scheduleName;
     return this;
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/utils/WorkflowStatusInternalBuilder.java
+++ b/transact/src/test/java/dev/dbos/transact/utils/WorkflowStatusInternalBuilder.java
@@ -5,6 +5,7 @@ import dev.dbos.transact.workflow.internal.WorkflowStatusInternal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 
 public class WorkflowStatusInternalBuilder {
   private String workflowId;
@@ -27,6 +28,8 @@ public class WorkflowStatusInternalBuilder {
   private Instant deadline;
   private String parentWorkflowId;
   private String serialization;
+  private String scheduleName;
+  private Map<String, Object> attributes;
 
   public static WorkflowStatusInternalBuilder create(String workflowId) {
     return new WorkflowStatusInternalBuilder().workflowId(workflowId);
@@ -132,6 +135,16 @@ public class WorkflowStatusInternalBuilder {
     return this;
   }
 
+  public WorkflowStatusInternalBuilder scheduleName(String scheduleName) {
+    this.scheduleName = scheduleName;
+    return this;
+  }
+
+  public WorkflowStatusInternalBuilder attributes(Map<String, Object> attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+
   public WorkflowStatusInternal build() {
     return new WorkflowStatusInternal(
         workflowId,
@@ -154,6 +167,7 @@ public class WorkflowStatusInternalBuilder {
         deadline,
         parentWorkflowId,
         serialization,
-        null);
+        attributes,
+        scheduleName);
   }
 }


### PR DESCRIPTION
changes to conductor to unblock all conductor integration tests (except local/remote license).

* Added migration 41 to track schedule name in workflow status table along w/ code to read & write that column (WorkflowDAO, WorkflowStatus, SchedulerService, etc)
* added schedule name support to ListWorkflows (including conductor protocol)
* added attributes filter to GetWorkflowAggregates (including conductor)
* added completed/dequeued before/after support to conductor ListQueuedWorkflowsRequest (underlying ListWorkflows already supported these clauses)



