### PR TITLE
Read rows other applications wrote without failing on their payloads

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -438,6 +438,16 @@ public class SystemDatabase implements AutoCloseable {
   }
 
   /**
+   * The error column of a workflow or a step, or null when it records no error.
+   *
+   * <p>The Go SDK stores the error as a non-nullable string, so a workflow that succeeded leaves ""
+   * behind where this one writes NULL. Empty only: no SDK writes a blank non-empty value.
+   */
+  public static String errorOrNull(String error) {
+    return error != null && error.isEmpty() ? null : error;
+  }
+
+  /**
    * Initializes the status of a workflow.
    *
    * @param initStatus The initial workflow status details.

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
@@ -1,6 +1,7 @@
 package dev.dbos.transact.database.dao;
 
 import dev.dbos.transact.database.DbContext;
+import dev.dbos.transact.database.SystemDatabase;
 import dev.dbos.transact.exceptions.*;
 import dev.dbos.transact.internal.DebugTriggers;
 import dev.dbos.transact.json.DBOSSerializer;
@@ -144,7 +145,7 @@ public class StepsDAO {
       try (ResultSet rs = pstmt.executeQuery()) {
         if (rs.next()) { // Check if any operation output row exists
           String output = rs.getString("output");
-          String error = rs.getString("error");
+          String error = SystemDatabase.errorOrNull(rs.getString("error"));
           String _stepName = rs.getString("function_name");
           String serialization = rs.getString("serialization");
           result =
@@ -222,7 +223,7 @@ public class StepsDAO {
           int functionId = rs.getInt("function_id");
           String functionName = rs.getString("function_name");
           String outputData = rs.getString("output");
-          String errorData = rs.getString("error");
+          String errorData = SystemDatabase.errorOrNull(rs.getString("error"));
           String childWorkflowId = rs.getString("child_workflow_id");
           Long startedAt = rs.getObject("started_at_epoch_ms", Long.class);
           Long completedAt = rs.getObject("completed_at_epoch_ms", Long.class);

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
@@ -232,7 +232,10 @@ public class StepsDAO {
           Object outputVal = null;
           ErrorResult stepError = null;
 
-          if (Objects.requireNonNullElse(loadOutput, true)) {
+          // As for a workflow's status: the steps are what is wanted, the payloads one field of
+          // each. See SerializationUtil.canDeserialize.
+          if (Objects.requireNonNullElse(loadOutput, true)
+              && SerializationUtil.canDeserialize(serialization, serializer)) {
             if (outputData != null) {
               try {
                 outputVal =

--- a/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
@@ -1233,7 +1233,7 @@ public class WorkflowDAO {
     String attributesJson = rs.getString("attributes");
     String serializedInput = loadInput ? rs.getString("inputs") : null;
     String serializedOutput = loadOutput ? rs.getString("output") : null;
-    String serializedError = loadOutput ? rs.getString("error") : null;
+    String serializedError = loadOutput ? SystemDatabase.errorOrNull(rs.getString("error")) : null;
     String serialization = loadInput || loadOutput ? rs.getString("serialization") : null;
     WorkflowStatus info =
         new WorkflowStatus(
@@ -1327,7 +1327,7 @@ public class WorkflowDAO {
               }
 
               case ERROR -> {
-                String error = rs.getString("error");
+                String error = SystemDatabase.errorOrNull(rs.getString("error"));
                 Throwable t = SerializationUtil.deserializeError(error, serialization, serializer);
                 return Result.failure(t);
               }

--- a/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
@@ -25,6 +25,7 @@ import dev.dbos.transact.workflow.GetStepAggregatesInput;
 import dev.dbos.transact.workflow.GetWorkflowAggregatesInput;
 import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.StepAggregateRow;
+import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.WorkflowAggregateRow;
 import dev.dbos.transact.workflow.WorkflowDelay;
 import dev.dbos.transact.workflow.WorkflowEvent;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1235,6 +1237,9 @@ public class WorkflowDAO {
     String serializedOutput = loadOutput ? rs.getString("output") : null;
     String serializedError = loadOutput ? SystemDatabase.errorOrNull(rs.getString("error")) : null;
     String serialization = loadInput || loadOutput ? rs.getString("serialization") : null;
+    // A status read reaches other applications' rows on purpose, and wants their metadata; an
+    // unreadable payload comes back null rather than failing the read.
+    boolean readable = SerializationUtil.canDeserialize(serialization, serializer);
     WorkflowStatus info =
         new WorkflowStatus(
             rs.getString("workflow_uuid"),
@@ -1247,14 +1252,16 @@ public class WorkflowDAO {
             (authenticatedRolesJson != null)
                 ? JsonUtility.fromJson(authenticatedRolesJson, new TypeReference<List<String>>() {})
                 : null,
-            loadInput
+            loadInput && readable
                 ? SerializationUtil.deserializePositionalArgs(
                     serializedInput, serialization, serializer)
                 : null,
-            loadOutput
+            loadOutput && readable
                 ? SerializationUtil.deserializeValue(serializedOutput, serialization, serializer)
                 : null,
-            loadOutput ? ErrorResult.deserialize(serializedError, serialization, serializer) : null,
+            loadOutput && readable
+                ? ErrorResult.deserialize(serializedError, serialization, serializer)
+                : null,
             rs.getString("executor_id"),
             SystemDatabase.toInstant(rs.getObject("created_at", Long.class)),
             SystemDatabase.toInstant(rs.getObject("updated_at", Long.class)),
@@ -2246,6 +2253,35 @@ public class WorkflowDAO {
     return streams;
   }
 
+  /**
+   * Refuse to move a workflow whose payloads this runtime cannot handle.
+   *
+   * <p>Export and import round-trip the payloads through this runtime's serializers, so neither can
+   * settle for the null a status read reports: a payload dropped on the way through restores a
+   * workflow that never had it.
+   */
+  private static void requireSerializerFor(
+      String action,
+      String workflowId,
+      String workflowSerialization,
+      List<StepInfo> steps,
+      DBOSSerializer serializer) {
+    var formats = new LinkedHashSet<String>();
+    if (!SerializationUtil.canDeserialize(workflowSerialization, serializer)) {
+      formats.add(workflowSerialization);
+    }
+    for (var step : steps) {
+      if (!SerializationUtil.canDeserialize(step.serialization(), serializer)) {
+        formats.add(step.serialization());
+      }
+    }
+    if (!formats.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot %s workflow %s: it is serialized as %s, which this application has no serializer for"
+              .formatted(action, workflowId, String.join(", ", formats)));
+    }
+  }
+
   public static List<ExportedWorkflow> exportWorkflow(
       DbContext ctx, String workflowId, boolean exportChildren) throws SQLException {
 
@@ -2263,6 +2299,9 @@ public class WorkflowDAO {
         var steps =
             StepsDAO.listWorkflowSteps(
                 conn, ctx.schema(), ctx.serializer(), wfid, true, null, null);
+        if (status != null) {
+          requireSerializerFor("export", wfid, status.serialization(), steps, ctx.serializer());
+        }
         var events = listWorkflowEvents(conn, ctx.schema(), wfid);
         var eventHistory = listWorkflowEventHistory(conn, ctx.schema(), wfid);
         var streams = listWorkflowStreams(conn, ctx.schema(), wfid);
@@ -2276,6 +2315,14 @@ public class WorkflowDAO {
       throws SQLException {
 
     DBOSSerializer serializer = ctx.serializer();
+    // The whole batch, before anything is written: export and import are a single-SDK affair but
+    // not a single-configuration one, and a payload we cannot re-serialize imports empty.
+    for (var workflow : workflows) {
+      var s = workflow.status();
+      requireSerializerFor(
+          "import", s.workflowId(), s.serialization(), workflow.steps(), serializer);
+    }
+
     var wfSQL =
         """
         INSERT INTO "%s".workflow_status (

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -1696,6 +1696,22 @@ public class DBOSExecutor implements AutoCloseable {
       throw new DBOSNonExistentWorkflowException(workflowId);
     }
 
+    // Reading the row reports an unreadable payload as null, so running the workflow refuses for
+    // itself: a workflow invoked with arguments it never had is worse than one marked ERROR.
+    if (!SerializationUtil.canDeserialize(status.serialization(), serializer)) {
+      var e =
+          new IllegalStateException(
+              "Cannot run workflow %s: its arguments are serialized as %s, which this application has no deserializer for"
+                  .formatted(workflowId, status.serialization()));
+      logger.error("Unreadable serialization for workflow {}", workflowId, e);
+      // Recorded in this runtime's own format, not the row's: a format we cannot read is one
+      // we cannot write either, and serializing the error into it would throw and leave the
+      // workflow PENDING forever — the hang this refusal exists to prevent. The status is the
+      // part that has to land.
+      persistWorkflowError(workflowId, e, null);
+      throw e;
+    }
+
     Object[] inputs = status.input();
     var wfName =
         RegisteredWorkflow.fullyQualifiedName(

--- a/transact/src/main/java/dev/dbos/transact/json/SerializationUtil.java
+++ b/transact/src/main/java/dev/dbos/transact/json/SerializationUtil.java
@@ -26,6 +26,19 @@ public final class SerializationUtil {
 
   private SerializationUtil() {}
 
+  /**
+   * Whether this runtime can read the given serialization format.
+   *
+   * <p>The two built-in formats always, and a custom serializer only for the format it names. A
+   * null format is the native one, written before the column existed.
+   */
+  public static boolean canDeserialize(String serialization, DBOSSerializer customSerializer) {
+    if (serialization == null || PORTABLE.equals(serialization) || NATIVE.equals(serialization)) {
+      return true;
+    }
+    return customSerializer != null && customSerializer.name().equals(serialization);
+  }
+
   // ============ Value Serialization ============
 
   /**

--- a/transact/src/main/java/dev/dbos/transact/txstep/TxStepSchema.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/TxStepSchema.java
@@ -1,5 +1,6 @@
 package dev.dbos.transact.txstep;
 
+import dev.dbos.transact.database.SystemDatabase;
 import dev.dbos.transact.workflow.internal.StepResult;
 
 import java.sql.Connection;
@@ -66,7 +67,7 @@ public class TxStepSchema {
             stepId,
             stepName,
             rs.getString("output"),
-            rs.getString("error"),
+            SystemDatabase.errorOrNull(rs.getString("error")),
             null,
             rs.getString("serialization")));
   }

--- a/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
+++ b/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
@@ -229,6 +229,66 @@ public class InteropTest {
     }
   }
 
+  /**
+   * Insert a completed workflow row as another SDK would leave it.
+   *
+   * <p>{@code serialization} and {@code error} are what vary between them: Go stores the error as a
+   * non-nullable string and so writes "" for a workflow that succeeded, and every SDK writes its
+   * own native format unless the workflow was declared portable.
+   */
+  private void insertPeerWorkflowRow(
+      String workflowId, String serialization, String inputs, String output, String error)
+      throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      String sql =
+          """
+          INSERT INTO dbos.workflow_status(
+            workflow_uuid, name, class_name, config_name,
+            status, inputs, output, error, created_at, serialization, application_name
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setString(2, "echoWorkflow");
+        stmt.setString(3, "interop");
+        stmt.setString(4, null);
+        stmt.setString(5, "SUCCESS");
+        stmt.setString(6, inputs);
+        stmt.setString(7, output);
+        stmt.setString(8, error);
+        stmt.setLong(9, System.currentTimeMillis());
+        stmt.setString(10, serialization);
+        stmt.setString(11, "interop-peer");
+        stmt.executeUpdate();
+      }
+    }
+  }
+
+  /** Insert a completed step row as another SDK would leave it. */
+  private void insertPeerStepRow(
+      String workflowId, String serialization, String output, String error) throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      String sql =
+          """
+          INSERT INTO dbos.operation_outputs(
+            workflow_uuid, function_id, function_name, output, error, serialization, application_name
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          """;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setInt(2, 0);
+        stmt.setString(3, "echoStep");
+        stmt.setString(4, output);
+        stmt.setString(5, error);
+        stmt.setString(6, serialization);
+        stmt.setString(7, "interop-peer");
+        stmt.executeUpdate();
+      }
+    }
+  }
+
   private void insertPortableNotification(String destinationUuid, String topic, String messageJson)
       throws Exception {
     try (Connection conn = dataSource.getConnection()) {
@@ -421,5 +481,47 @@ public class InteropTest {
       assertEquals(42, ((Number) storedNamedArgs.get("count")).intValue());
       assertEquals(Arrays.asList("a", "b"), storedNamedArgs.get("tags"));
     }
+  }
+
+  // ============================================================================
+  // Test: reading a workflow another application owns
+  // ============================================================================
+
+  /**
+   * A workflow that succeeded, whose error column holds "" rather than NULL.
+   *
+   * <p>That is what the Go SDK leaves behind — it stores the error as a non-nullable string — and
+   * on a shared system database this runtime is routinely asked about such a row. An empty column
+   * has to mean the same thing as an absent one; parsing it as JSON does not.
+   */
+  @Test
+  public void testStatusReadTreatsAnEmptyErrorColumnAsNoError() throws Exception {
+    String workflowId = "peer-empty-error";
+    insertPeerWorkflowRow(
+        workflowId, "portable_json", "{\"positionalArgs\":[]}", "{\"ok\":true}", "");
+
+    dbos.launch();
+    var status = dbos.getWorkflowStatus(workflowId).orElseThrow();
+
+    assertEquals(WorkflowState.SUCCESS, status.status());
+    assertNull(status.error(), "an empty error column is not an error");
+  }
+
+  /**
+   * A step of a peer's workflow, recorded with an empty error column.
+   *
+   * <p>Steps carry the same column with the same quirk, so they get the same reading.
+   */
+  @Test
+  public void testStepReadTreatsAnEmptyErrorColumnAsNoError() throws Exception {
+    String workflowId = "peer-step-empty-error";
+    insertPeerWorkflowRow(workflowId, "portable_json", "{\"positionalArgs\":[]}", "{}", "");
+    insertPeerStepRow(workflowId, "portable_json", "{\"ok\":true}", "");
+
+    dbos.launch();
+    var steps = dbos.listWorkflowSteps(workflowId);
+
+    assertEquals(1, steps.size());
+    assertNull(steps.get(0).error(), "an empty error column is not an error");
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
+++ b/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
@@ -4,15 +4,20 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import dev.dbos.transact.DBOS;
 import dev.dbos.transact.DBOSClient;
+import dev.dbos.transact.DBOSTestAccess;
 import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.utils.DBUtils;
 import dev.dbos.transact.utils.PgContainer;
+import dev.dbos.transact.workflow.ExportedWorkflow;
+import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.SerializationStrategy;
+import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.Workflow;
 import dev.dbos.transact.workflow.WorkflowClassName;
 import dev.dbos.transact.workflow.WorkflowHandle;
 import dev.dbos.transact.workflow.WorkflowState;
+import dev.dbos.transact.workflow.internal.StepResult;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -508,6 +513,52 @@ public class InteropTest {
   }
 
   /**
+   * A workflow another application ran, in a serialization format this runtime cannot read.
+   *
+   * <p>Workflow IDs address the whole system database, so a status read reaches a peer's rows on
+   * purpose — and what is wanted there is the metadata: who owns it, what it is, whether it
+   * finished. A payload in the peer's own format must not take that away, so the fields that cannot
+   * be deserialized come back null and the read succeeds. Python behaves the same way, in
+   * safe_deserialize.
+   */
+  @Test
+  public void testStatusReadOfAPeerRowInAnUnreadableFormat() throws Exception {
+    String workflowId = "peer-foreign-format";
+    insertPeerWorkflowRow(workflowId, "py_pickle", "gASVCgAAAA==", "gASVBAAAAA==", null);
+
+    dbos.launch();
+    var status = dbos.getWorkflowStatus(workflowId).orElseThrow();
+
+    // The metadata is the point, and it is all there.
+    assertEquals(workflowId, status.workflowId());
+    assertEquals("echoWorkflow", status.workflowName());
+    assertEquals(WorkflowState.SUCCESS, status.status());
+    assertEquals("interop-peer", status.applicationName());
+    assertEquals("py_pickle", status.serialization());
+
+    // The payloads are not, and saying so beats failing the whole read.
+    assertNull(status.input());
+    assertNull(status.output());
+    assertNull(status.error());
+  }
+
+  /** The same row, through the listing rather than by ID. */
+  @Test
+  public void testListingAPeerRowInAnUnreadableFormat() throws Exception {
+    String workflowId = "peer-foreign-format-listed";
+    insertPeerWorkflowRow(workflowId, "py_pickle", "gASVCgAAAA==", "gASVBAAAAA==", "");
+
+    dbos.launch();
+    var listed = dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIds(workflowId)).get(0);
+
+    assertEquals(workflowId, listed.workflowId());
+    assertEquals("interop-peer", listed.applicationName());
+    assertNull(listed.input());
+    assertNull(listed.output());
+    assertNull(listed.error());
+  }
+
+  /**
    * A step of a peer's workflow, recorded with an empty error column.
    *
    * <p>Steps carry the same column with the same quirk, so they get the same reading.
@@ -523,5 +574,102 @@ public class InteropTest {
 
     assertEquals(1, steps.size());
     assertNull(steps.get(0).error(), "an empty error column is not an error");
+  }
+
+  /**
+   * The same gap without another language in it: two Java applications on one system database, one
+   * configured with a custom serializer and one not.
+   *
+   * <p>`custom_base64` is a format this runtime has no deserializer for, exactly as `py_pickle` is,
+   * and canDeserialize says so without having to try and fail.
+   */
+  @Test
+  public void testStatusReadOfARowWrittenByACustomSerializerWeLack() throws Exception {
+    String workflowId = "peer-custom-serializer";
+    insertPeerWorkflowRow(workflowId, "custom_base64", "cG9zaXRpb25hbA==", "b3V0cHV0", null);
+
+    dbos.launch();
+    var status = dbos.getWorkflowStatus(workflowId).orElseThrow();
+
+    assertEquals(WorkflowState.SUCCESS, status.status());
+    assertEquals("custom_base64", status.serialization());
+    assertNull(status.input());
+    assertNull(status.output());
+  }
+
+  /**
+   * Exporting a workflow this runtime cannot read is refused rather than silently emptied.
+   *
+   * <p>A status read reports an unreadable payload as null, which is right when the metadata is
+   * what was asked for. An export is imported back, so the same null would restore a workflow that
+   * never had an input.
+   */
+  @Test
+  public void testExportRefusesAWorkflowItCannotRead() throws Exception {
+    String workflowId = "peer-export";
+    insertPeerWorkflowRow(workflowId, "py_pickle", "gASVCgAAAA==", "gASVBAAAAA==", null);
+
+    dbos.launch();
+    var systemDatabase = DBOSTestAccess.getSystemDatabase(dbos);
+
+    var thrown =
+        assertThrows(
+            IllegalStateException.class, () -> systemDatabase.exportWorkflow(workflowId, false));
+    assertTrue(
+        thrown.getMessage().contains("py_pickle"),
+        "The refusal should name the format it could not read, got: " + thrown.getMessage());
+  }
+
+  /**
+   * Importing one is refused too, before anything is written.
+   *
+   * <p>Export and import are a single-SDK affair, but not a single-configuration one: the source
+   * application may have had a serializer this one does not. Import re-serializes the payloads, so
+   * it needs that serializer as much as export did — and a payload the export already carried as
+   * null would otherwise be written as NULL and committed.
+   */
+  @Test
+  public void testImportRefusesAWorkflowItCannotRead() throws Exception {
+    String workflowId = "peer-import";
+    insertPeerWorkflowRow(workflowId, "portable_json", "{\"positionalArgs\":[]}", "{}", null);
+
+    dbos.launch();
+    var systemDatabase = DBOSTestAccess.getSystemDatabase(dbos);
+
+    // Exported readably, then given a step in a format this application has no serializer for —
+    // which is what a batch arriving from an application configured differently looks like.
+    var exported = systemDatabase.exportWorkflow(workflowId, false).get(0);
+    var foreignStep =
+        new StepInfo(
+            0, "echoStep", "cG9zaXRpb25hbA==", null, null, null, null, "custom_base64", null);
+    var batch =
+        List.of(
+            new ExportedWorkflow(
+                exported.status(),
+                List.of(foreignStep),
+                exported.events(),
+                exported.eventHistory(),
+                exported.streams()));
+
+    var thrown =
+        assertThrows(IllegalStateException.class, () -> systemDatabase.importWorkflow(batch));
+    assertTrue(
+        thrown.getMessage().contains("custom_base64"),
+        "The refusal should name the format, got: " + thrown.getMessage());
+  }
+
+  /**
+   * Replaying a step whose result this application cannot read fails; it does not replay as null.
+   *
+   * <p>The tolerant reads are the ones that assemble a record. A recorded step result is consumed
+   * to continue a workflow — a step that "returned null" because its output could not be read would
+   * corrupt the run it is replaying, silently and durably.
+   */
+  @Test
+  public void testStepResultRefusesToReplayWhatItCannotRead() {
+    var recorded =
+        new StepResult("wf", 0, "echoStep", "cG9zaXRpb25hbA==", null, null, "custom_base64");
+
+    assertThrows(IllegalArgumentException.class, () -> recorded.toResult(null));
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/json/PortableSerializationTest.java
+++ b/transact/src/test/java/dev/dbos/transact/json/PortableSerializationTest.java
@@ -1036,6 +1036,60 @@ public class PortableSerializationTest {
     throw new AssertionError("Workflow " + workflowId + " did not reach terminal state in time");
   }
 
+  /** Insert an enqueued workflow row carrying an arbitrary serialization format. */
+  private void insertEnqueuedRowWithSerialization(
+      String workflowId, String queueName, String inputsJson, String serialization)
+      throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      String sql =
+          """
+          INSERT INTO dbos.workflow_status(
+            workflow_uuid, name, class_name, config_name,
+            queue_name, status, inputs, created_at, serialization
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setString(2, "recvWorkflow");
+        stmt.setString(3, "PortableTestService");
+        stmt.setString(4, null);
+        stmt.setString(5, queueName);
+        stmt.setString(6, "ENQUEUED");
+        stmt.setString(7, inputsJson);
+        stmt.setLong(8, System.currentTimeMillis());
+        stmt.setString(9, serialization);
+        stmt.executeUpdate();
+      }
+    }
+  }
+
+  /**
+   * A workflow whose arguments are in a format this application cannot read is marked ERROR, not
+   * left in PENDING.
+   *
+   * <p>Reading the row does not fail on such a format any more — a status read reports the
+   * arguments as null and hands back the metadata — so running the workflow has to refuse for
+   * itself, and say which format it would have taken.
+   */
+  @Test
+  public void testUnreadableSerializationMarksTheWorkflowErrored() throws Exception {
+    Queue testQueue = new Queue("testq");
+    dbos.registerQueue(testQueue);
+    dbos.registerProxy(PortableTestService.class, new PortableTestServiceImpl(dbos));
+    dbos.launch();
+
+    String workflowId = UUID.randomUUID().toString();
+    insertEnqueuedRowWithSerialization(workflowId, "testq", "cGlja2xlZA==", "py_pickle");
+
+    var row = waitForWorkflowTerminal(workflowId, Duration.ofSeconds(30));
+    assertEquals(WorkflowState.ERROR.name(), row.status());
+    assertNotNull(row.error());
+    assertTrue(
+        row.error().contains("py_pickle"),
+        "The error should name the format it could not read, got: " + row.error());
+  }
+
   /**
    * Tests that completely invalid (unparseable) JSON in the inputs column results in the workflow
    * being marked as ERROR rather than being stuck in PENDING forever.


### PR DESCRIPTION
Two bugs a Java application hits when it shares a system database with applications it did not write. Both surfaced in the `interops` demo, where Java, Python, TypeScript and Go apps drive each other's workflows through one `dbos` schema.

## Read an empty error column as no error

The Go SDK stores a workflow's error as a non-nullable string, so a workflow that *succeeded* leaves `""` in `error` where this SDK writes NULL. Java treated any non-null value as an error and parsed it as JSON, so reading a perfectly healthy Go workflow threw:

```
MismatchedInputException: No content to map due to end-of-input
```

The other SDKs already tolerate both spellings — TypeScript coerces on the way in (`row.error ? row.error : null`), Python never reads the column unless the status says ERROR. `SystemDatabase.errorOrNull` does the same at each site that reads the column: a workflow's, a step's, and the transactional step schema's.

Empty, not blank. No SDK writes a non-empty run of whitespace here, so a blank-but-not-empty value is content to hand back rather than quietly discard. What this SDK *writes* is unchanged and stays conservative: an absent error is NULL.

## Don't try to deserialize a format we don't recognize

`getWorkflowStatus` threw `IllegalArgumentException: Serialization is not available` on any row written in a format this runtime has no deserializer for. Workflow IDs address the whole system database, so a status read reaches another application's rows *on purpose*, and what is wanted from such a row is the metadata — who owns it, what it is, whether it finished. Losing all of it over a payload the caller may not have asked for is the wrong trade.

Not only an interop problem: two Java applications on one system database, one configured with a custom serializer and one not, hit exactly this. `custom_base64` is as unreadable here as `py_pickle` is.

`SerializationUtil.canDeserialize` asks the question directly rather than catching a failure — the two built-in formats, plus whatever a configured custom serializer names. The reads that assemble a record from a row skip the payloads when the answer is no and report them as null.

**Only where the payload is one field of a record** — a workflow's status, a workflow's steps. Everywhere the payload *is* the answer still throws, because there is nothing else to hand back: `getEvent`, a workflow's result, a recv'd message, a stream, and a recorded step result on replay. That last one matters most, since a step that "returned null" because its output could not be read would corrupt the run it is replaying, so it has a test of its own.

Three paths read a record but must not accept a null payload, and check for themselves:

- **Running a workflow.** The arguments are the point, and one invoked with arguments it never had is worse than one marked ERROR. `executeWorkflowById` refuses and names the format. The error is recorded in this runtime's own format: one we cannot read is one we cannot write, and serializing into it would throw and leave the workflow PENDING forever — the hang this refusal exists to prevent.
- **Exporting one.** An export is imported back, so a payload dropped on the way out restores a workflow that never had it. Conductor can ask an application to export a peer's workflow, which is exactly when this bites.
- **Importing one.** Import re-serializes every payload, so it needs a serializer for the recorded format as much as export did, and it writes a null payload straight through as NULL — a lossy batch would import as an emptied workflow rather than an error. Checked for the whole batch before the transaction opens.

## Testing

- 632 tests pass; `spotlessCheck`, `javadoc` and `compileTestJava` green.
- New `InteropTest` cases cover both empty-error reads, peer rows in an unreadable format (status and listing), a custom serializer this app lacks, the export and import refusals, and the step-replay refusal.
- New `PortableSerializationTest` case drives an ENQUEUED `py_pickle` row through the executor and asserts it lands ERROR naming the format, rather than hanging PENDING.
- Verified end to end against the `interops` demo: 57 tests pass with the four-language apps sharing one system database, built against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
