### PR TITLE
Compatibility fixes for system database sharing

### DIFF
--- a/transact/src/main/java/dev/dbos/transact/DBOSClient.java
+++ b/transact/src/main/java/dev/dbos/transact/DBOSClient.java
@@ -371,6 +371,49 @@ public class DBOSClient implements AutoCloseable {
           null);
     }
 
+    /**
+     * Constructs options with no explicit owning application, which enqueues the workflow for the
+     * enqueueing application.
+     */
+    public EnqueueOptions(
+        @NonNull String workflowName,
+        @Nullable String className,
+        @Nullable String instanceName,
+        @NonNull String queueName,
+        @Nullable String workflowId,
+        @Nullable String appVersion,
+        @Nullable Duration timeout,
+        @Nullable Instant deadline,
+        @Nullable String deduplicationId,
+        @Nullable Integer priority,
+        @Nullable String queuePartitionKey,
+        @Nullable Duration delay,
+        @Nullable SerializationStrategy serialization,
+        @Nullable String authenticatedUser,
+        @Nullable String assumedRole,
+        @Nullable List<String> authenticatedRoles,
+        @Nullable Map<String, Object> attributes) {
+      this(
+          workflowName,
+          className,
+          instanceName,
+          queueName,
+          workflowId,
+          appVersion,
+          timeout,
+          deadline,
+          deduplicationId,
+          priority,
+          queuePartitionKey,
+          delay,
+          serialization,
+          authenticatedUser,
+          assumedRole,
+          authenticatedRoles,
+          attributes,
+          null);
+    }
+
     public EnqueueOptions(
         @NonNull String workflowName, @Nullable String className, @NonNull String queueName) {
       this(

--- a/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
+++ b/transact/src/main/java/dev/dbos/transact/database/SystemDatabase.java
@@ -438,6 +438,16 @@ public class SystemDatabase implements AutoCloseable {
   }
 
   /**
+   * The error column of a workflow or a step, or null when it records no error.
+   *
+   * <p>The Go SDK stores the error as a non-nullable string, so a workflow that succeeded leaves ""
+   * behind where this one writes NULL. Empty only: no SDK writes a blank non-empty value.
+   */
+  public static String errorOrNull(String error) {
+    return error != null && error.isEmpty() ? null : error;
+  }
+
+  /**
    * Initializes the status of a workflow.
    *
    * @param initStatus The initial workflow status details.

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
@@ -1,6 +1,7 @@
 package dev.dbos.transact.database.dao;
 
 import dev.dbos.transact.database.DbContext;
+import dev.dbos.transact.database.SystemDatabase;
 import dev.dbos.transact.exceptions.*;
 import dev.dbos.transact.internal.DebugTriggers;
 import dev.dbos.transact.json.DBOSSerializer;
@@ -144,7 +145,7 @@ public class StepsDAO {
       try (ResultSet rs = pstmt.executeQuery()) {
         if (rs.next()) { // Check if any operation output row exists
           String output = rs.getString("output");
-          String error = rs.getString("error");
+          String error = SystemDatabase.errorOrNull(rs.getString("error"));
           String _stepName = rs.getString("function_name");
           String serialization = rs.getString("serialization");
           result =
@@ -222,7 +223,7 @@ public class StepsDAO {
           int functionId = rs.getInt("function_id");
           String functionName = rs.getString("function_name");
           String outputData = rs.getString("output");
-          String errorData = rs.getString("error");
+          String errorData = SystemDatabase.errorOrNull(rs.getString("error"));
           String childWorkflowId = rs.getString("child_workflow_id");
           Long startedAt = rs.getObject("started_at_epoch_ms", Long.class);
           Long completedAt = rs.getObject("completed_at_epoch_ms", Long.class);

--- a/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/StepsDAO.java
@@ -232,7 +232,10 @@ public class StepsDAO {
           Object outputVal = null;
           ErrorResult stepError = null;
 
-          if (Objects.requireNonNullElse(loadOutput, true)) {
+          // As for a workflow's status: the steps are what is wanted, the payloads one field of
+          // each. See SerializationUtil.canDeserialize.
+          if (Objects.requireNonNullElse(loadOutput, true)
+              && SerializationUtil.canDeserialize(serialization, serializer)) {
             if (outputData != null) {
               try {
                 outputVal =

--- a/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
@@ -1233,7 +1233,7 @@ public class WorkflowDAO {
     String attributesJson = rs.getString("attributes");
     String serializedInput = loadInput ? rs.getString("inputs") : null;
     String serializedOutput = loadOutput ? rs.getString("output") : null;
-    String serializedError = loadOutput ? rs.getString("error") : null;
+    String serializedError = loadOutput ? SystemDatabase.errorOrNull(rs.getString("error")) : null;
     String serialization = loadInput || loadOutput ? rs.getString("serialization") : null;
     WorkflowStatus info =
         new WorkflowStatus(
@@ -1327,7 +1327,7 @@ public class WorkflowDAO {
               }
 
               case ERROR -> {
-                String error = rs.getString("error");
+                String error = SystemDatabase.errorOrNull(rs.getString("error"));
                 Throwable t = SerializationUtil.deserializeError(error, serialization, serializer);
                 return Result.failure(t);
               }

--- a/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
+++ b/transact/src/main/java/dev/dbos/transact/database/dao/WorkflowDAO.java
@@ -25,6 +25,7 @@ import dev.dbos.transact.workflow.GetStepAggregatesInput;
 import dev.dbos.transact.workflow.GetWorkflowAggregatesInput;
 import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.StepAggregateRow;
+import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.WorkflowAggregateRow;
 import dev.dbos.transact.workflow.WorkflowDelay;
 import dev.dbos.transact.workflow.WorkflowEvent;
@@ -47,6 +48,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -1235,6 +1237,9 @@ public class WorkflowDAO {
     String serializedOutput = loadOutput ? rs.getString("output") : null;
     String serializedError = loadOutput ? SystemDatabase.errorOrNull(rs.getString("error")) : null;
     String serialization = loadInput || loadOutput ? rs.getString("serialization") : null;
+    // A status read reaches other applications' rows on purpose, and wants their metadata; an
+    // unreadable payload comes back null rather than failing the read.
+    boolean readable = SerializationUtil.canDeserialize(serialization, serializer);
     WorkflowStatus info =
         new WorkflowStatus(
             rs.getString("workflow_uuid"),
@@ -1247,14 +1252,16 @@ public class WorkflowDAO {
             (authenticatedRolesJson != null)
                 ? JsonUtility.fromJson(authenticatedRolesJson, new TypeReference<List<String>>() {})
                 : null,
-            loadInput
+            loadInput && readable
                 ? SerializationUtil.deserializePositionalArgs(
                     serializedInput, serialization, serializer)
                 : null,
-            loadOutput
+            loadOutput && readable
                 ? SerializationUtil.deserializeValue(serializedOutput, serialization, serializer)
                 : null,
-            loadOutput ? ErrorResult.deserialize(serializedError, serialization, serializer) : null,
+            loadOutput && readable
+                ? ErrorResult.deserialize(serializedError, serialization, serializer)
+                : null,
             rs.getString("executor_id"),
             SystemDatabase.toInstant(rs.getObject("created_at", Long.class)),
             SystemDatabase.toInstant(rs.getObject("updated_at", Long.class)),
@@ -2246,6 +2253,35 @@ public class WorkflowDAO {
     return streams;
   }
 
+  /**
+   * Refuse to move a workflow whose payloads this runtime cannot handle.
+   *
+   * <p>Export and import round-trip the payloads through this runtime's serializers, so neither can
+   * settle for the null a status read reports: a payload dropped on the way through restores a
+   * workflow that never had it.
+   */
+  private static void requireSerializerFor(
+      String action,
+      String workflowId,
+      String workflowSerialization,
+      List<StepInfo> steps,
+      DBOSSerializer serializer) {
+    var formats = new LinkedHashSet<String>();
+    if (!SerializationUtil.canDeserialize(workflowSerialization, serializer)) {
+      formats.add(workflowSerialization);
+    }
+    for (var step : steps) {
+      if (!SerializationUtil.canDeserialize(step.serialization(), serializer)) {
+        formats.add(step.serialization());
+      }
+    }
+    if (!formats.isEmpty()) {
+      throw new IllegalStateException(
+          "Cannot %s workflow %s: it is serialized as %s, which this application has no serializer for"
+              .formatted(action, workflowId, String.join(", ", formats)));
+    }
+  }
+
   public static List<ExportedWorkflow> exportWorkflow(
       DbContext ctx, String workflowId, boolean exportChildren) throws SQLException {
 
@@ -2263,6 +2299,9 @@ public class WorkflowDAO {
         var steps =
             StepsDAO.listWorkflowSteps(
                 conn, ctx.schema(), ctx.serializer(), wfid, true, null, null);
+        if (status != null) {
+          requireSerializerFor("export", wfid, status.serialization(), steps, ctx.serializer());
+        }
         var events = listWorkflowEvents(conn, ctx.schema(), wfid);
         var eventHistory = listWorkflowEventHistory(conn, ctx.schema(), wfid);
         var streams = listWorkflowStreams(conn, ctx.schema(), wfid);
@@ -2276,6 +2315,14 @@ public class WorkflowDAO {
       throws SQLException {
 
     DBOSSerializer serializer = ctx.serializer();
+    // The whole batch, before anything is written: export and import are a single-SDK affair but
+    // not a single-configuration one, and a payload we cannot re-serialize imports empty.
+    for (var workflow : workflows) {
+      var s = workflow.status();
+      requireSerializerFor(
+          "import", s.workflowId(), s.serialization(), workflow.steps(), serializer);
+    }
+
     var wfSQL =
         """
         INSERT INTO "%s".workflow_status (

--- a/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
+++ b/transact/src/main/java/dev/dbos/transact/execution/DBOSExecutor.java
@@ -1696,6 +1696,22 @@ public class DBOSExecutor implements AutoCloseable {
       throw new DBOSNonExistentWorkflowException(workflowId);
     }
 
+    // Reading the row reports an unreadable payload as null, so running the workflow refuses for
+    // itself: a workflow invoked with arguments it never had is worse than one marked ERROR.
+    if (!SerializationUtil.canDeserialize(status.serialization(), serializer)) {
+      var e =
+          new IllegalStateException(
+              "Cannot run workflow %s: its arguments are serialized as %s, which this application has no deserializer for"
+                  .formatted(workflowId, status.serialization()));
+      logger.error("Unreadable serialization for workflow {}", workflowId, e);
+      // Recorded in this runtime's own format, not the row's: a format we cannot read is one
+      // we cannot write either, and serializing the error into it would throw and leave the
+      // workflow PENDING forever — the hang this refusal exists to prevent. The status is the
+      // part that has to land.
+      persistWorkflowError(workflowId, e, null);
+      throw e;
+    }
+
     Object[] inputs = status.input();
     var wfName =
         RegisteredWorkflow.fullyQualifiedName(

--- a/transact/src/main/java/dev/dbos/transact/json/SerializationUtil.java
+++ b/transact/src/main/java/dev/dbos/transact/json/SerializationUtil.java
@@ -26,6 +26,19 @@ public final class SerializationUtil {
 
   private SerializationUtil() {}
 
+  /**
+   * Whether this runtime can read the given serialization format.
+   *
+   * <p>The two built-in formats always, and a custom serializer only for the format it names. A
+   * null format is the native one, written before the column existed.
+   */
+  public static boolean canDeserialize(String serialization, DBOSSerializer customSerializer) {
+    if (serialization == null || PORTABLE.equals(serialization) || NATIVE.equals(serialization)) {
+      return true;
+    }
+    return customSerializer != null && customSerializer.name().equals(serialization);
+  }
+
   // ============ Value Serialization ============
 
   /**

--- a/transact/src/main/java/dev/dbos/transact/txstep/TxStepSchema.java
+++ b/transact/src/main/java/dev/dbos/transact/txstep/TxStepSchema.java
@@ -1,5 +1,6 @@
 package dev.dbos.transact.txstep;
 
+import dev.dbos.transact.database.SystemDatabase;
 import dev.dbos.transact.workflow.internal.StepResult;
 
 import java.sql.Connection;
@@ -66,7 +67,7 @@ public class TxStepSchema {
             stepId,
             stepName,
             rs.getString("output"),
-            rs.getString("error"),
+            SystemDatabase.errorOrNull(rs.getString("error")),
             null,
             rs.getString("serialization")));
   }

--- a/transact/src/main/java/dev/dbos/transact/workflow/GetStepAggregatesInput.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/GetStepAggregatesInput.java
@@ -41,6 +41,35 @@ public record GetStepAggregatesInput(
     }
   }
 
+  /**
+   * Constructs an input with no application filter, which covers this application's own steps plus
+   * unclaimed ones.
+   */
+  public GetStepAggregatesInput(
+      boolean groupByFunctionName,
+      boolean groupByStatus,
+      boolean selectCount,
+      boolean selectMaxDuration,
+      Duration timeBucketSize,
+      List<String> status,
+      List<String> functionName,
+      List<String> workflowIdPrefix,
+      Instant completedAfter,
+      Instant completedBefore) {
+    this(
+        groupByFunctionName,
+        groupByStatus,
+        selectCount,
+        selectMaxDuration,
+        timeBucketSize,
+        status,
+        functionName,
+        workflowIdPrefix,
+        completedAfter,
+        completedBefore,
+        null);
+  }
+
   public GetStepAggregatesInput() {
     this(false, false, true, false, null, null, null, null, null, null, null);
   }

--- a/transact/src/main/java/dev/dbos/transact/workflow/GetWorkflowAggregatesInput.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/GetWorkflowAggregatesInput.java
@@ -65,6 +65,62 @@ public record GetWorkflowAggregatesInput(
   }
 
   /** Constructs a default input with {@code selectCount=true} and no group-by or filter flags. */
+  /**
+   * Constructs an input with no application filter and no grouping by application, which covers
+   * this application's own workflows plus unclaimed ones.
+   */
+  public GetWorkflowAggregatesInput(
+      boolean groupByStatus,
+      boolean groupByName,
+      boolean groupByQueueName,
+      boolean groupByExecutorId,
+      boolean groupByApplicationVersion,
+      boolean selectCount,
+      boolean selectMinCreatedAt,
+      boolean selectMaxQueueWait,
+      boolean selectMaxTotalLatency,
+      Duration timeBucketSize,
+      List<String> workflowName,
+      List<String> status,
+      List<String> queueName,
+      List<String> executorIds,
+      List<String> applicationVersion,
+      List<String> workflowIdPrefix,
+      Instant startTime,
+      Instant endTime,
+      Instant completedAfter,
+      Instant completedBefore,
+      Instant dequeuedAfter,
+      Instant dequeuedBefore,
+      Map<String, Object> attributes) {
+    this(
+        groupByStatus,
+        groupByName,
+        groupByQueueName,
+        groupByExecutorId,
+        groupByApplicationVersion,
+        false,
+        selectCount,
+        selectMinCreatedAt,
+        selectMaxQueueWait,
+        selectMaxTotalLatency,
+        timeBucketSize,
+        workflowName,
+        status,
+        queueName,
+        executorIds,
+        applicationVersion,
+        null,
+        workflowIdPrefix,
+        startTime,
+        endTime,
+        completedAfter,
+        completedBefore,
+        dequeuedAfter,
+        dequeuedBefore,
+        attributes);
+  }
+
   public GetWorkflowAggregatesInput() {
     this(
         false, false, false, false, false, false, true, false, false, false, null, null, null, null,

--- a/transact/src/main/java/dev/dbos/transact/workflow/ListWorkflowsInput.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/ListWorkflowsInput.java
@@ -54,6 +54,71 @@ public record ListWorkflowsInput(
     attributes = validateAttributes(attributes);
   }
 
+  /**
+   * Constructs an input with no application filter, which covers this application's own workflows
+   * plus unclaimed ones.
+   */
+  public ListWorkflowsInput(
+      List<String> workflowIds,
+      List<WorkflowState> status,
+      Instant startTime,
+      Instant endTime,
+      List<String> workflowName,
+      String className,
+      String instanceName,
+      List<String> applicationVersion,
+      List<String> authenticatedUser,
+      Integer limit,
+      Integer offset,
+      Boolean sortDesc,
+      List<String> workflowIdPrefix,
+      Boolean loadInput,
+      Boolean loadOutput,
+      List<String> queueName,
+      Boolean queuesOnly,
+      List<String> executorIds,
+      List<String> forkedFrom,
+      List<String> parentWorkflowId,
+      Boolean wasForkedFrom,
+      Boolean hasParent,
+      Map<String, Object> attributes,
+      Instant completedAfter,
+      Instant completedBefore,
+      Instant dequeuedAfter,
+      Instant dequeuedBefore,
+      List<String> scheduleName) {
+    this(
+        workflowIds,
+        status,
+        startTime,
+        endTime,
+        workflowName,
+        className,
+        instanceName,
+        applicationVersion,
+        authenticatedUser,
+        limit,
+        offset,
+        sortDesc,
+        workflowIdPrefix,
+        loadInput,
+        loadOutput,
+        queueName,
+        queuesOnly,
+        executorIds,
+        forkedFrom,
+        parentWorkflowId,
+        wasForkedFrom,
+        hasParent,
+        attributes,
+        completedAfter,
+        completedBefore,
+        dequeuedAfter,
+        dequeuedBefore,
+        scheduleName,
+        null);
+  }
+
   public ListWorkflowsInput() {
     this(
         null, null, null, null, null, null, null, null, null, null, null, null, null, null, null,

--- a/transact/src/main/java/dev/dbos/transact/workflow/Queue.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/Queue.java
@@ -45,6 +45,29 @@ public record Queue(
       throw new IllegalArgumentException("Queue pollingInterval must be greater than zero");
   }
 
+  /**
+   * Constructs a queue with no explicit owning application, which records the registering
+   * application as the owner.
+   */
+  public Queue(
+      @NonNull String name,
+      @Nullable Integer concurrency,
+      @Nullable Integer workerConcurrency,
+      boolean priorityEnabled,
+      boolean partitioningEnabled,
+      @Nullable RateLimit rateLimit,
+      @NonNull Duration pollingInterval) {
+    this(
+        name,
+        concurrency,
+        workerConcurrency,
+        priorityEnabled,
+        partitioningEnabled,
+        rateLimit,
+        pollingInterval,
+        null);
+  }
+
   /** Construct a queue with a given name */
   public Queue(@NonNull String name) {
     this(name, null, null, false, false, null, DEFAULT_POLLING_INTERVAL, null);

--- a/transact/src/main/java/dev/dbos/transact/workflow/WorkflowSchedule.java
+++ b/transact/src/main/java/dev/dbos/transact/workflow/WorkflowSchedule.java
@@ -39,6 +39,37 @@ public record WorkflowSchedule(
     Objects.requireNonNull(status, "status must not be null");
   }
 
+  /**
+   * Constructs a schedule with no explicit owning application, which records the creating
+   * application as the owner.
+   */
+  public WorkflowSchedule(
+      @Nullable String id,
+      @NonNull String scheduleName,
+      @NonNull String workflowName,
+      @Nullable String className,
+      @NonNull String cron,
+      @NonNull ScheduleStatus status,
+      @Nullable Object context,
+      @Nullable Instant lastFiredAt,
+      boolean automaticBackfill,
+      @Nullable ZoneId cronTimezone,
+      @Nullable String queueName) {
+    this(
+        id,
+        scheduleName,
+        workflowName,
+        className,
+        cron,
+        status,
+        context,
+        lastFiredAt,
+        automaticBackfill,
+        cronTimezone,
+        queueName,
+        null);
+  }
+
   public WorkflowSchedule(
       @NonNull String scheduleName,
       @NonNull String workflowName,

--- a/transact/src/test/java/dev/dbos/transact/client/EnqueueOptionsTest.java
+++ b/transact/src/test/java/dev/dbos/transact/client/EnqueueOptionsTest.java
@@ -1,10 +1,16 @@
 package dev.dbos.transact.client;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import dev.dbos.transact.DBOSClient;
+import dev.dbos.transact.workflow.SerializationStrategy;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -49,5 +55,60 @@ public class EnqueueOptionsTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> new DBOSClient.EnqueueOptions("wf-name", "q-name").withDelay(Duration.ofSeconds(-1)));
+  }
+
+  /**
+   * The constructor omitting the application name exists so callers that predate system database
+   * sharing keep compiling. It delegates positionally, so it is compared against the canonical
+   * constructor to catch a mis-ordered delegation, which would otherwise compile cleanly.
+   */
+  @Test
+  public void constructorWithoutAnApplicationNameEnqueuesForTheEnqueueingApplication() {
+    var attributes = Map.<String, Object>of("key", "value");
+    var roles = List.of("role");
+
+    var actual =
+        new DBOSClient.EnqueueOptions(
+            "workflow-name",
+            "class-name",
+            "instance-name",
+            "queue-name",
+            "workflow-id",
+            "app-version",
+            Duration.ofSeconds(1),
+            Instant.ofEpochSecond(2),
+            "deduplication-id",
+            3,
+            "queue-partition-key",
+            Duration.ofSeconds(4),
+            SerializationStrategy.PORTABLE,
+            "authenticated-user",
+            "assumed-role",
+            roles,
+            attributes);
+
+    var expected =
+        new DBOSClient.EnqueueOptions(
+            "workflow-name",
+            "class-name",
+            "instance-name",
+            "queue-name",
+            "workflow-id",
+            "app-version",
+            Duration.ofSeconds(1),
+            Instant.ofEpochSecond(2),
+            "deduplication-id",
+            3,
+            "queue-partition-key",
+            Duration.ofSeconds(4),
+            SerializationStrategy.PORTABLE,
+            "authenticated-user",
+            "assumed-role",
+            roles,
+            attributes,
+            null);
+
+    assertNull(actual.applicationName());
+    assertEquals(expected, actual);
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
+++ b/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
@@ -229,6 +229,66 @@ public class InteropTest {
     }
   }
 
+  /**
+   * Insert a completed workflow row as another SDK would leave it.
+   *
+   * <p>{@code serialization} and {@code error} are what vary between them: Go stores the error as a
+   * non-nullable string and so writes "" for a workflow that succeeded, and every SDK writes its
+   * own native format unless the workflow was declared portable.
+   */
+  private void insertPeerWorkflowRow(
+      String workflowId, String serialization, String inputs, String output, String error)
+      throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      String sql =
+          """
+          INSERT INTO dbos.workflow_status(
+            workflow_uuid, name, class_name, config_name,
+            status, inputs, output, error, created_at, serialization, application_name
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setString(2, "echoWorkflow");
+        stmt.setString(3, "interop");
+        stmt.setString(4, null);
+        stmt.setString(5, "SUCCESS");
+        stmt.setString(6, inputs);
+        stmt.setString(7, output);
+        stmt.setString(8, error);
+        stmt.setLong(9, System.currentTimeMillis());
+        stmt.setString(10, serialization);
+        stmt.setString(11, "interop-peer");
+        stmt.executeUpdate();
+      }
+    }
+  }
+
+  /** Insert a completed step row as another SDK would leave it. */
+  private void insertPeerStepRow(
+      String workflowId, String serialization, String output, String error) throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      String sql =
+          """
+          INSERT INTO dbos.operation_outputs(
+            workflow_uuid, function_id, function_name, output, error, serialization, application_name
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?)
+          """;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setInt(2, 0);
+        stmt.setString(3, "echoStep");
+        stmt.setString(4, output);
+        stmt.setString(5, error);
+        stmt.setString(6, serialization);
+        stmt.setString(7, "interop-peer");
+        stmt.executeUpdate();
+      }
+    }
+  }
+
   private void insertPortableNotification(String destinationUuid, String topic, String messageJson)
       throws Exception {
     try (Connection conn = dataSource.getConnection()) {
@@ -421,5 +481,47 @@ public class InteropTest {
       assertEquals(42, ((Number) storedNamedArgs.get("count")).intValue());
       assertEquals(Arrays.asList("a", "b"), storedNamedArgs.get("tags"));
     }
+  }
+
+  // ============================================================================
+  // Test: reading a workflow another application owns
+  // ============================================================================
+
+  /**
+   * A workflow that succeeded, whose error column holds "" rather than NULL.
+   *
+   * <p>That is what the Go SDK leaves behind — it stores the error as a non-nullable string — and
+   * on a shared system database this runtime is routinely asked about such a row. An empty column
+   * has to mean the same thing as an absent one; parsing it as JSON does not.
+   */
+  @Test
+  public void testStatusReadTreatsAnEmptyErrorColumnAsNoError() throws Exception {
+    String workflowId = "peer-empty-error";
+    insertPeerWorkflowRow(
+        workflowId, "portable_json", "{\"positionalArgs\":[]}", "{\"ok\":true}", "");
+
+    dbos.launch();
+    var status = dbos.getWorkflowStatus(workflowId).orElseThrow();
+
+    assertEquals(WorkflowState.SUCCESS, status.status());
+    assertNull(status.error(), "an empty error column is not an error");
+  }
+
+  /**
+   * A step of a peer's workflow, recorded with an empty error column.
+   *
+   * <p>Steps carry the same column with the same quirk, so they get the same reading.
+   */
+  @Test
+  public void testStepReadTreatsAnEmptyErrorColumnAsNoError() throws Exception {
+    String workflowId = "peer-step-empty-error";
+    insertPeerWorkflowRow(workflowId, "portable_json", "{\"positionalArgs\":[]}", "{}", "");
+    insertPeerStepRow(workflowId, "portable_json", "{\"ok\":true}", "");
+
+    dbos.launch();
+    var steps = dbos.listWorkflowSteps(workflowId);
+
+    assertEquals(1, steps.size());
+    assertNull(steps.get(0).error(), "an empty error column is not an error");
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
+++ b/transact/src/test/java/dev/dbos/transact/json/InteropTest.java
@@ -4,15 +4,20 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import dev.dbos.transact.DBOS;
 import dev.dbos.transact.DBOSClient;
+import dev.dbos.transact.DBOSTestAccess;
 import dev.dbos.transact.config.DBOSConfig;
 import dev.dbos.transact.utils.DBUtils;
 import dev.dbos.transact.utils.PgContainer;
+import dev.dbos.transact.workflow.ExportedWorkflow;
+import dev.dbos.transact.workflow.ListWorkflowsInput;
 import dev.dbos.transact.workflow.Queue;
 import dev.dbos.transact.workflow.SerializationStrategy;
+import dev.dbos.transact.workflow.StepInfo;
 import dev.dbos.transact.workflow.Workflow;
 import dev.dbos.transact.workflow.WorkflowClassName;
 import dev.dbos.transact.workflow.WorkflowHandle;
 import dev.dbos.transact.workflow.WorkflowState;
+import dev.dbos.transact.workflow.internal.StepResult;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -508,6 +513,52 @@ public class InteropTest {
   }
 
   /**
+   * A workflow another application ran, in a serialization format this runtime cannot read.
+   *
+   * <p>Workflow IDs address the whole system database, so a status read reaches a peer's rows on
+   * purpose — and what is wanted there is the metadata: who owns it, what it is, whether it
+   * finished. A payload in the peer's own format must not take that away, so the fields that cannot
+   * be deserialized come back null and the read succeeds. Python behaves the same way, in
+   * safe_deserialize.
+   */
+  @Test
+  public void testStatusReadOfAPeerRowInAnUnreadableFormat() throws Exception {
+    String workflowId = "peer-foreign-format";
+    insertPeerWorkflowRow(workflowId, "py_pickle", "gASVCgAAAA==", "gASVBAAAAA==", null);
+
+    dbos.launch();
+    var status = dbos.getWorkflowStatus(workflowId).orElseThrow();
+
+    // The metadata is the point, and it is all there.
+    assertEquals(workflowId, status.workflowId());
+    assertEquals("echoWorkflow", status.workflowName());
+    assertEquals(WorkflowState.SUCCESS, status.status());
+    assertEquals("interop-peer", status.applicationName());
+    assertEquals("py_pickle", status.serialization());
+
+    // The payloads are not, and saying so beats failing the whole read.
+    assertNull(status.input());
+    assertNull(status.output());
+    assertNull(status.error());
+  }
+
+  /** The same row, through the listing rather than by ID. */
+  @Test
+  public void testListingAPeerRowInAnUnreadableFormat() throws Exception {
+    String workflowId = "peer-foreign-format-listed";
+    insertPeerWorkflowRow(workflowId, "py_pickle", "gASVCgAAAA==", "gASVBAAAAA==", "");
+
+    dbos.launch();
+    var listed = dbos.listWorkflows(new ListWorkflowsInput().withWorkflowIds(workflowId)).get(0);
+
+    assertEquals(workflowId, listed.workflowId());
+    assertEquals("interop-peer", listed.applicationName());
+    assertNull(listed.input());
+    assertNull(listed.output());
+    assertNull(listed.error());
+  }
+
+  /**
    * A step of a peer's workflow, recorded with an empty error column.
    *
    * <p>Steps carry the same column with the same quirk, so they get the same reading.
@@ -523,5 +574,102 @@ public class InteropTest {
 
     assertEquals(1, steps.size());
     assertNull(steps.get(0).error(), "an empty error column is not an error");
+  }
+
+  /**
+   * The same gap without another language in it: two Java applications on one system database, one
+   * configured with a custom serializer and one not.
+   *
+   * <p>`custom_base64` is a format this runtime has no deserializer for, exactly as `py_pickle` is,
+   * and canDeserialize says so without having to try and fail.
+   */
+  @Test
+  public void testStatusReadOfARowWrittenByACustomSerializerWeLack() throws Exception {
+    String workflowId = "peer-custom-serializer";
+    insertPeerWorkflowRow(workflowId, "custom_base64", "cG9zaXRpb25hbA==", "b3V0cHV0", null);
+
+    dbos.launch();
+    var status = dbos.getWorkflowStatus(workflowId).orElseThrow();
+
+    assertEquals(WorkflowState.SUCCESS, status.status());
+    assertEquals("custom_base64", status.serialization());
+    assertNull(status.input());
+    assertNull(status.output());
+  }
+
+  /**
+   * Exporting a workflow this runtime cannot read is refused rather than silently emptied.
+   *
+   * <p>A status read reports an unreadable payload as null, which is right when the metadata is
+   * what was asked for. An export is imported back, so the same null would restore a workflow that
+   * never had an input.
+   */
+  @Test
+  public void testExportRefusesAWorkflowItCannotRead() throws Exception {
+    String workflowId = "peer-export";
+    insertPeerWorkflowRow(workflowId, "py_pickle", "gASVCgAAAA==", "gASVBAAAAA==", null);
+
+    dbos.launch();
+    var systemDatabase = DBOSTestAccess.getSystemDatabase(dbos);
+
+    var thrown =
+        assertThrows(
+            IllegalStateException.class, () -> systemDatabase.exportWorkflow(workflowId, false));
+    assertTrue(
+        thrown.getMessage().contains("py_pickle"),
+        "The refusal should name the format it could not read, got: " + thrown.getMessage());
+  }
+
+  /**
+   * Importing one is refused too, before anything is written.
+   *
+   * <p>Export and import are a single-SDK affair, but not a single-configuration one: the source
+   * application may have had a serializer this one does not. Import re-serializes the payloads, so
+   * it needs that serializer as much as export did — and a payload the export already carried as
+   * null would otherwise be written as NULL and committed.
+   */
+  @Test
+  public void testImportRefusesAWorkflowItCannotRead() throws Exception {
+    String workflowId = "peer-import";
+    insertPeerWorkflowRow(workflowId, "portable_json", "{\"positionalArgs\":[]}", "{}", null);
+
+    dbos.launch();
+    var systemDatabase = DBOSTestAccess.getSystemDatabase(dbos);
+
+    // Exported readably, then given a step in a format this application has no serializer for —
+    // which is what a batch arriving from an application configured differently looks like.
+    var exported = systemDatabase.exportWorkflow(workflowId, false).get(0);
+    var foreignStep =
+        new StepInfo(
+            0, "echoStep", "cG9zaXRpb25hbA==", null, null, null, null, "custom_base64", null);
+    var batch =
+        List.of(
+            new ExportedWorkflow(
+                exported.status(),
+                List.of(foreignStep),
+                exported.events(),
+                exported.eventHistory(),
+                exported.streams()));
+
+    var thrown =
+        assertThrows(IllegalStateException.class, () -> systemDatabase.importWorkflow(batch));
+    assertTrue(
+        thrown.getMessage().contains("custom_base64"),
+        "The refusal should name the format, got: " + thrown.getMessage());
+  }
+
+  /**
+   * Replaying a step whose result this application cannot read fails; it does not replay as null.
+   *
+   * <p>The tolerant reads are the ones that assemble a record. A recorded step result is consumed
+   * to continue a workflow — a step that "returned null" because its output could not be read would
+   * corrupt the run it is replaying, silently and durably.
+   */
+  @Test
+  public void testStepResultRefusesToReplayWhatItCannotRead() {
+    var recorded =
+        new StepResult("wf", 0, "echoStep", "cG9zaXRpb25hbA==", null, null, "custom_base64");
+
+    assertThrows(IllegalArgumentException.class, () -> recorded.toResult(null));
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/json/PortableSerializationTest.java
+++ b/transact/src/test/java/dev/dbos/transact/json/PortableSerializationTest.java
@@ -1036,6 +1036,60 @@ public class PortableSerializationTest {
     throw new AssertionError("Workflow " + workflowId + " did not reach terminal state in time");
   }
 
+  /** Insert an enqueued workflow row carrying an arbitrary serialization format. */
+  private void insertEnqueuedRowWithSerialization(
+      String workflowId, String queueName, String inputsJson, String serialization)
+      throws Exception {
+    try (Connection conn = dataSource.getConnection()) {
+      String sql =
+          """
+          INSERT INTO dbos.workflow_status(
+            workflow_uuid, name, class_name, config_name,
+            queue_name, status, inputs, created_at, serialization
+          )
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          """;
+      try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+        stmt.setString(1, workflowId);
+        stmt.setString(2, "recvWorkflow");
+        stmt.setString(3, "PortableTestService");
+        stmt.setString(4, null);
+        stmt.setString(5, queueName);
+        stmt.setString(6, "ENQUEUED");
+        stmt.setString(7, inputsJson);
+        stmt.setLong(8, System.currentTimeMillis());
+        stmt.setString(9, serialization);
+        stmt.executeUpdate();
+      }
+    }
+  }
+
+  /**
+   * A workflow whose arguments are in a format this application cannot read is marked ERROR, not
+   * left in PENDING.
+   *
+   * <p>Reading the row does not fail on such a format any more — a status read reports the
+   * arguments as null and hands back the metadata — so running the workflow has to refuse for
+   * itself, and say which format it would have taken.
+   */
+  @Test
+  public void testUnreadableSerializationMarksTheWorkflowErrored() throws Exception {
+    Queue testQueue = new Queue("testq");
+    dbos.registerQueue(testQueue);
+    dbos.registerProxy(PortableTestService.class, new PortableTestServiceImpl(dbos));
+    dbos.launch();
+
+    String workflowId = UUID.randomUUID().toString();
+    insertEnqueuedRowWithSerialization(workflowId, "testq", "cGlja2xlZA==", "py_pickle");
+
+    var row = waitForWorkflowTerminal(workflowId, Duration.ofSeconds(30));
+    assertEquals(WorkflowState.ERROR.name(), row.status());
+    assertNotNull(row.error());
+    assertTrue(
+        row.error().contains("py_pickle"),
+        "The error should name the format it could not read, got: " + row.error());
+  }
+
   /**
    * Tests that completely invalid (unparseable) JSON in the inputs column results in the workflow
    * being marked as ERROR rather than being stuck in PENDING forever.

--- a/transact/src/test/java/dev/dbos/transact/workflow/OmittedApplicationNameTest.java
+++ b/transact/src/test/java/dev/dbos/transact/workflow/OmittedApplicationNameTest.java
@@ -6,13 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * Covers the constructors that omit the trailing application name, which exist so callers that
- * predate system database sharing keep compiling. They delegate positionally, so each component is
- * checked to catch a mis-ordered delegation, which would otherwise compile cleanly.
+ * Covers the constructors that omit the application name, which exist so callers that predate
+ * system database sharing keep compiling. They delegate positionally, so each is checked against
+ * the canonical constructor to catch a mis-ordered delegation, which would otherwise compile
+ * cleanly. Distinct values per component are what make a swapped pair visible.
  */
 class OmittedApplicationNameTest {
 
@@ -60,5 +63,172 @@ class OmittedApplicationNameTest {
     assertEquals(true, queue.partitioningEnabled());
     assertEquals(rateLimit, queue.rateLimit());
     assertEquals(Duration.ofSeconds(7), queue.pollingInterval());
+  }
+
+  @Test
+  void listWorkflowsInputConstructedWithoutAnApplicationNameFiltersOnNone() {
+    var attributes = Map.<String, Object>of("key", "value");
+    var actual =
+        new ListWorkflowsInput(
+            List.of("workflow-ids"),
+            List.of(WorkflowState.SUCCESS),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2),
+            List.of("workflow-name"),
+            "class-name",
+            "instance-name",
+            List.of("application-version"),
+            List.of("authenticated-user"),
+            10,
+            20,
+            true,
+            List.of("workflow-id-prefix"),
+            true,
+            false,
+            List.of("queue-name"),
+            true,
+            List.of("executor-ids"),
+            List.of("forked-from"),
+            List.of("parent-workflow-id"),
+            false,
+            true,
+            attributes,
+            Instant.ofEpochSecond(3),
+            Instant.ofEpochSecond(4),
+            Instant.ofEpochSecond(5),
+            Instant.ofEpochSecond(6),
+            List.of("schedule-name"));
+
+    var expected =
+        new ListWorkflowsInput(
+            List.of("workflow-ids"),
+            List.of(WorkflowState.SUCCESS),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2),
+            List.of("workflow-name"),
+            "class-name",
+            "instance-name",
+            List.of("application-version"),
+            List.of("authenticated-user"),
+            10,
+            20,
+            true,
+            List.of("workflow-id-prefix"),
+            true,
+            false,
+            List.of("queue-name"),
+            true,
+            List.of("executor-ids"),
+            List.of("forked-from"),
+            List.of("parent-workflow-id"),
+            false,
+            true,
+            attributes,
+            Instant.ofEpochSecond(3),
+            Instant.ofEpochSecond(4),
+            Instant.ofEpochSecond(5),
+            Instant.ofEpochSecond(6),
+            List.of("schedule-name"),
+            null);
+
+    assertNull(actual.applicationName());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  void getStepAggregatesInputConstructedWithoutAnApplicationNameFiltersOnNone() {
+    var actual =
+        new GetStepAggregatesInput(
+            true,
+            false,
+            true,
+            false,
+            Duration.ofSeconds(30),
+            List.of("status"),
+            List.of("function-name"),
+            List.of("workflow-id-prefix"),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2));
+
+    var expected =
+        new GetStepAggregatesInput(
+            true,
+            false,
+            true,
+            false,
+            Duration.ofSeconds(30),
+            List.of("status"),
+            List.of("function-name"),
+            List.of("workflow-id-prefix"),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2),
+            null);
+
+    assertNull(actual.applicationName());
+    assertEquals(expected, actual);
+  }
+
+  // The two components #471 added here landed mid-list rather than appended, so this delegation
+  // has to reorder its arguments rather than just pass an extra null.
+  @Test
+  void getWorkflowAggregatesInputConstructedWithoutAnApplicationNameFiltersOnNone() {
+    var attributes = Map.<String, Object>of("key", "value");
+    var actual =
+        new GetWorkflowAggregatesInput(
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            Duration.ofSeconds(30),
+            List.of("workflow-name"),
+            List.of("status"),
+            List.of("queue-name"),
+            List.of("executor-ids"),
+            List.of("application-version"),
+            List.of("workflow-id-prefix"),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2),
+            Instant.ofEpochSecond(3),
+            Instant.ofEpochSecond(4),
+            Instant.ofEpochSecond(5),
+            Instant.ofEpochSecond(6),
+            attributes);
+
+    var expected =
+        new GetWorkflowAggregatesInput(
+            true,
+            false,
+            true,
+            false,
+            true,
+            false, // groupByApplicationName
+            false,
+            true,
+            false,
+            true,
+            Duration.ofSeconds(30),
+            List.of("workflow-name"),
+            List.of("status"),
+            List.of("queue-name"),
+            List.of("executor-ids"),
+            List.of("application-version"),
+            null, // applicationName
+            List.of("workflow-id-prefix"),
+            Instant.ofEpochSecond(1),
+            Instant.ofEpochSecond(2),
+            Instant.ofEpochSecond(3),
+            Instant.ofEpochSecond(4),
+            Instant.ofEpochSecond(5),
+            Instant.ofEpochSecond(6),
+            attributes);
+
+    assertNull(actual.applicationName());
+    assertEquals(false, actual.groupByApplicationName());
+    assertEquals(expected, actual);
   }
 }

--- a/transact/src/test/java/dev/dbos/transact/workflow/OmittedApplicationNameTest.java
+++ b/transact/src/test/java/dev/dbos/transact/workflow/OmittedApplicationNameTest.java
@@ -1,0 +1,64 @@
+package dev.dbos.transact.workflow;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Covers the constructors that omit the trailing application name, which exist so callers that
+ * predate system database sharing keep compiling. They delegate positionally, so each component is
+ * checked to catch a mis-ordered delegation, which would otherwise compile cleanly.
+ */
+class OmittedApplicationNameTest {
+
+  @Test
+  void scheduleConstructedWithoutAnApplicationNameIsUnclaimed() {
+    var lastFiredAt = Instant.ofEpochSecond(1_700_000_000L);
+    var schedule =
+        new WorkflowSchedule(
+            "schedule-id",
+            "schedule-name",
+            "workflow-name",
+            "class-name",
+            "* * * * * *",
+            ScheduleStatus.PAUSED,
+            "context",
+            lastFiredAt,
+            true,
+            ZoneId.of("America/New_York"),
+            "queue-name");
+
+    assertNull(schedule.applicationName());
+    assertEquals("schedule-id", schedule.id());
+    assertEquals("schedule-name", schedule.scheduleName());
+    assertEquals("workflow-name", schedule.workflowName());
+    assertEquals("class-name", schedule.className());
+    assertEquals("* * * * * *", schedule.cron());
+    assertEquals(ScheduleStatus.PAUSED, schedule.status());
+    assertEquals("context", schedule.context());
+    assertEquals(lastFiredAt, schedule.lastFiredAt());
+    assertEquals(true, schedule.automaticBackfill());
+    assertEquals(ZoneId.of("America/New_York"), schedule.cronTimezone());
+    assertEquals("queue-name", schedule.queueName());
+  }
+
+  @Test
+  void queueConstructedWithoutAnApplicationNameIsUnclaimed() {
+    var rateLimit = new Queue.RateLimit(5, Duration.ofSeconds(10));
+    var queue = new Queue("queue-name", 3, 2, true, true, rateLimit, Duration.ofSeconds(7));
+
+    assertNull(queue.applicationName());
+    assertEquals("queue-name", queue.name());
+    assertEquals(3, queue.concurrency());
+    assertEquals(2, queue.workerConcurrency());
+    assertEquals(true, queue.priorityEnabled());
+    assertEquals(true, queue.partitioningEnabled());
+    assertEquals(rateLimit, queue.rateLimit());
+    assertEquals(Duration.ofSeconds(7), queue.pollingInterval());
+  }
+}


### PR DESCRIPTION
Compatibility fallout from #471, which added application names and system
database sharing. Two independent kinds, in one PR because they share that
cause.

The first three commits were opened before as #475, which was closed unmerged;
they are unchanged here.

## Reading rows another application wrote

Sharing a system database means a read can land on a row this runtime did not
write, and two such reads failed outright.

**Read an empty error column as no error** (`e07f89b`). The Go SDK stores a
workflow's error as a non-nullable string, so a workflow that *succeeded*
leaves `""` where this SDK writes NULL. Java parsed that as JSON and threw
`MismatchedInputException: No content to map due to end-of-input` — on a
workflow that never failed. TypeScript and Python already tolerate both forms.
Applied where the column is read, not inside the deserializers, which should
not have to know how a column came to be written. What this SDK writes is
unchanged.

**Don't try to deserialize a format we don't recognize** (`11897bc`).
`getWorkflowStatus` threw `IllegalArgumentException: Serialization is not
available` for any row in a format this runtime has no deserializer for. A
workflow ID addresses the whole database, so a status read reaches other
applications' rows by design, and what is wanted from one is the metadata.
This is not only cross-SDK: two Java apps on one database, one with a custom
serializer, hit it identically. `SerializationUtil.canDeserialize` now asks
directly, and the reads that assemble a record from a row report unreadable
payloads as null.

Only where the payload is *one field of a record*. Where the payload is the
answer it still throws — `getEvent`, a workflow's result, a recv'd message, a
stream, and a recorded step result on replay. That last one matters most: a
step that "returned null" because its output could not be read would corrupt
the run it is replaying, so it has a test of its own. Three paths read a record
but must not accept a null payload and check for themselves: running a workflow
(refusing rather than invoking it with arguments it never had), exporting one,
and importing one.

## Restoring constructors #471 broke

#471 added `applicationName` to a number of public records. For a Java record
that changes the *canonical constructor in place*, so every caller that built
one positionally stopped compiling — including the DBOS conductor test app,
whose CI cannot build against the published SDK
([failing run](https://github.com/dbos-inc/dbos-conductor/actions/runs/33212895492)):

```
App.java:277: error: no suitable constructor found for WorkflowSchedule(...)
```

**Restore constructors that omit the application name** (`2a7aeeb`) —
`WorkflowSchedule`, `Queue`.
**Restore input constructors that omit the application name** (`68297a2`) —
`ListWorkflowsInput`, `GetStepAggregatesInput`, `GetWorkflowAggregatesInput`.
**Restore the EnqueueOptions constructor that omits the application name**
(`3054cc6`) — `DBOSClient.EnqueueOptions`.

Each takes the pre-#471 argument list and forwards a null owner, which is the
same default the existing no-arg constructors already use: the creating or
enqueueing application for the records that record an owner, and "this
application's rows plus unclaimed ones" for the filters. `GetWorkflowAggregatesInput`
needed care — its two new components landed *mid-list* rather than appended, so
that delegation reorders its arguments and passes `groupByApplicationName` as
false.

### Scope

A sweep of every public signature #471 changed (1,614 → 1,678 across all six
published modules) found 30 changed in place. They fall out as:

| | Disposition |
|---|---|
| The 6 records above | Constructors restored |
| `WorkflowStatus`, `StepInfo`, `VersionInfo` | Left alone — callers receive these, they do not construct them |
| 21 internal signatures | Left to change in place — conductor wire DTOs, the DAO layer, `DbContext`, `SystemDatabase`, `DBOSExecutor`, and the `internal` packages |

Internal APIs deliberately get no compatibility overloads; they are fixed at
their call sites when they change. Only external app code, which cannot be
fixed that way, gets them.

No public interface, enum, or abstract class was modified, so there are no
implementor breaks, and no record component was removed or renamed — every
change was an addition. `transact-cli` only gained a new class.

### Testing

The overloads delegate positionally, where a mis-ordered argument would compile
cleanly and silently scramble fields, so each is compared against the canonical
constructor rather than spot-checked. Both new test classes are container-free.
Verified non-vacuous by mutation: swapping two same-typed arguments in the
`GetWorkflowAggregatesInput` and `EnqueueOptions` delegations makes the
corresponding test fail.

Note that this does not unblock conductor CI on its own — the test app resolves
`dev.dbos:transact:+`, so it needs a new prerelease published.
