### PR TITLE
Pool prebaked containers and reset them with DELETE

### DIFF
--- a/transact/src/test/java/dev/dbos/transact/migrations/CockroachMigrationTest.java
+++ b/transact/src/test/java/dev/dbos/transact/migrations/CockroachMigrationTest.java
@@ -8,14 +8,24 @@ import dev.dbos.transact.database.SystemDatabase;
 import dev.dbos.transact.utils.PgContainer;
 
 import java.sql.Connection;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Tests that LISTEN/NOTIFY functions and triggers are created on PG and omitted on CRDB. Each test
  * spins up its own container so these tests are always tied to the specified DB type regardless of
  * how PgContainer is configured for the rest of the test suite.
+ *
+ * <p>The suite-wide two-minute timeout does not fit these. Every test here starts a stock container
+ * and migrates it from empty, and on CockroachDB the corpus is tens of seconds of online schema
+ * changes even unloaded -- so on a small CI runner, with the rest of the suite running alongside,
+ * two minutes is a coin toss rather than a deadline. It became one when the pooled containers
+ * stopped migrating: the suite got denser, and the tests that still do the slow thing got less of
+ * the machine. Raised rather than removed, so a genuine hang still fails rather than hanging CI.
  */
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
 class CockroachMigrationTest {
 
   @Test

--- a/transact/src/test/java/dev/dbos/transact/utils/PgContainer.java
+++ b/transact/src/test/java/dev/dbos/transact/utils/PgContainer.java
@@ -8,6 +8,8 @@ import dev.dbos.transact.migrations.MigrationManager;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -15,26 +17,101 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import com.zaxxer.hikari.HikariDataSource;
 import org.testcontainers.cockroachdb.CockroachContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.postgresql.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 public class PgContainer implements AutoCloseable {
 
   public static final boolean USE_COCKROACH_DB =
       Boolean.parseBoolean(System.getenv("DBOS_TEST_USE_COCKROACH_DB"));
-  private static final String DB_NAME = "dbos_test_db";
+
+  /** The database a prebaked image ships, already migrated. */
+  private static final String POOLED_DB_NAME = "dbos_test_0";
+
+  /** What a from-empty container uses, since it has to create its own database anyway. */
+  private static final String FRESH_DB_NAME = "dbos_test_db";
+
+  /** Where a prebaked CockroachDB image keeps its store, which is not the default location. */
+  private static final String CRDB_STORE = "/cockroach/prebuilt";
 
   private static final Queue<JdbcDatabaseContainer<?>> POOL = new ConcurrentLinkedQueue<>();
 
+  private static String image(String variable, String fallback) {
+    var value = System.getenv(variable);
+    return value == null || value.isBlank() ? fallback : value;
+  }
+
+  // Pinned to a migration version rather than floating, so a migration landing in dbos-ctl cannot
+  // change what this suite runs against without a commit here saying so.
+  private static final String PG_IMAGE = image("DBOS_TEST_POSTGRES_IMAGE", "postgres:18");
+  private static final String CRDB_IMAGE =
+      image("DBOS_TEST_COCKROACH_IMAGE", "cockroachdb/cockroach:latest-v26.2");
+  private static final String PG_PREBAKED_IMAGE =
+      image("DBOS_TEST_POSTGRES_PREBAKED_IMAGE", "ghcr.io/dbos-inc/dbos-test-postgres:18-m108");
+  private static final String CRDB_PREBAKED_IMAGE =
+      image("DBOS_TEST_COCKROACH_PREBAKED_IMAGE", "ghcr.io/dbos-inc/dbos-test-cockroach:26.2-m108");
+
+  /** A stock PostgreSQL server with no DBOS schema. */
   public static PostgreSQLContainer getPG() {
-    return new PostgreSQLContainer("postgres:18");
+    return new PostgreSQLContainer(PG_IMAGE);
   }
 
+  /** A stock CockroachDB server with no DBOS schema. */
   public static CockroachContainer getCRDB() {
-    return new CockroachContainer("cockroachdb/cockroach:latest-v26.2");
+    return new CockroachContainer(CRDB_IMAGE);
   }
 
-  private static JdbcDatabaseContainer<?> containerSupplier() {
-    var container = USE_COCKROACH_DB ? getCRDB() : getPG();
+  /**
+   * A PostgreSQL server whose DBOS schema is already migrated.
+   *
+   * <p>The wait strategy has to be replaced rather than inherited. The stock one waits for
+   * "database system is ready to accept connections" <i>twice</i>, because a container that
+   * initialises itself starts the server once to run initdb and again to serve. This image arrives
+   * initialised, so the entrypoint skips that first pass and the message appears once -- against
+   * the stock strategy every container would sit until the startup timeout and then fail, having
+   * been ready the whole time.
+   *
+   * <p>The user has to be {@code postgres} for the same reason: {@code POSTGRES_USER} only takes
+   * effect during initdb, so an image that skips it has whatever roles it was built with.
+   */
+  private static PostgreSQLContainer prebakedPG() {
+    return new PostgreSQLContainer(
+            DockerImageName.parse(PG_PREBAKED_IMAGE).asCompatibleSubstituteFor("postgres"))
+        .withDatabaseName(POOLED_DB_NAME)
+        .withUsername("postgres")
+        .withPassword("dbos")
+        .waitingFor(
+            Wait.forLogMessage(".*database system is ready to accept connections.*\\s", 1)
+                .withStartupTimeout(Duration.ofMinutes(2)));
+  }
+
+  /**
+   * A CockroachDB server whose DBOS schema is already migrated.
+   *
+   * <p>The command has to name the store: a prebaked image keeps its baked data outside the default
+   * location precisely so a container that forgets to ask starts an empty node rather than silently
+   * appearing to work, and the stock command does not ask.
+   *
+   * <p>No password is set, and that is load-bearing. {@code CockroachContainer.configure()}
+   * replaces the command with a bare {@code start-single-node} when a password is present, which
+   * would drop both the store path and {@code --insecure}.
+   */
+  private static CockroachContainer prebakedCRDB() {
+    return new CockroachContainer(
+            DockerImageName.parse(CRDB_PREBAKED_IMAGE)
+                .asCompatibleSubstituteFor("cockroachdb/cockroach"))
+        .withDatabaseName(POOLED_DB_NAME)
+        .withCommand("start-single-node", "--insecure", "--store=path=" + CRDB_STORE);
+  }
+
+  private static JdbcDatabaseContainer<?> containerSupplier(boolean prebaked) {
+    JdbcDatabaseContainer<?> container;
+    if (prebaked) {
+      container = USE_COCKROACH_DB ? prebakedCRDB() : prebakedPG();
+    } else {
+      container = USE_COCKROACH_DB ? getCRDB() : getPG();
+    }
     container.start();
     return container;
   }
@@ -42,18 +119,23 @@ public class PgContainer implements AutoCloseable {
   static JdbcDatabaseContainer<?> acquire() {
     var container = POOL.poll();
     if (container != null) {
-      var jdbcUrl = container.getJdbcUrl().replaceFirst("/[^/]+$", "/" + DB_NAME);
+      var jdbcUrl = container.getJdbcUrl().replaceFirst("/[^/]+$", "/" + POOLED_DB_NAME);
       try (var conn =
           DriverManager.getConnection(jdbcUrl, container.getUsername(), container.getPassword())) {
-        truncateDbosTables(conn);
+        resetDbosTables(conn);
       } catch (SQLException e) {
         throw new RuntimeException(e);
       }
       return container;
     }
-    container = containerSupplier();
-    var jdbcUrl = container.getJdbcUrl().replaceFirst("/[^/]+$", "/" + DB_NAME);
+    container = containerSupplier(true);
+    var jdbcUrl = container.getJdbcUrl().replaceFirst("/[^/]+$", "/" + POOLED_DB_NAME);
 
+    // The image arrives migrated, so this is normally a no-op -- every SDK gates on
+    // `current < latest`. It is kept rather than deleted because it is what makes the pinned image
+    // tag a performance decision rather than a correctness one: if this build's migrations run
+    // ahead
+    // of the image, this applies the tail instead of failing.
     MigrationManager.runMigrations(
         jdbcUrl, container.getUsername(), container.getPassword(), "dbos", true);
     return container;
@@ -63,25 +145,42 @@ public class PgContainer implements AutoCloseable {
     POOL.offer(c);
   }
 
-  public static void truncateDbosTables(Connection conn) throws SQLException {
-    // truncate the DBOS tables from the test DB before returning to the pool
-    var truncate =
-        """
-        TRUNCATE TABLE
-          "dbos".workflow_status,
-          "dbos".operation_outputs,
-          "dbos".workflow_events,
-          "dbos".workflow_events_history,
-          "dbos".notifications,
-          "dbos".event_dispatch_kv,
-          "dbos".streams,
-          "dbos".application_versions,
-          "dbos".workflow_schedules,
-          "dbos".queues
-        CASCADE
-        """;
+  /**
+   * Empties every DBOS table, leaving the schema in place.
+   *
+   * <p>{@code DELETE}, not {@code TRUNCATE}: CockroachDB implements {@code TRUNCATE} as a schema
+   * change, so it prices like {@code CREATE INDEX} however few rows a table holds. Measured against
+   * this schema it costs 1.16s where the equivalent deletes cost 0.05s, and a pooled container is
+   * reset once per test -- roughly 900 times a run. {@code TRUNCATE} would win only once a table is
+   * big enough for row count to dominate, which no test fixture is.
+   *
+   * <p>The table list comes from the catalogue rather than a hard-coded list, so a migration that
+   * adds a table cannot silently leave it uncleaned. Deleting from all of them in one statement
+   * batch is safe in any order -- emptying everything cannot strand a foreign key.
+   */
+  public static void resetDbosTables(Connection conn) throws SQLException {
+    var tables = new ArrayList<String>();
+    try (var stmt = conn.createStatement();
+        var rs =
+            stmt.executeQuery(
+                """
+                SELECT table_name FROM information_schema.tables
+                WHERE table_schema = 'dbos' AND table_name <> 'dbos_migrations'
+                ORDER BY table_name
+                """)) {
+      while (rs.next()) {
+        tables.add(rs.getString(1));
+      }
+    }
+    if (tables.isEmpty()) {
+      return;
+    }
+    var deletes = new StringBuilder();
+    for (var table : tables) {
+      deletes.append("DELETE FROM \"dbos\".\"").append(table).append("\";");
+    }
     try (var stmt = conn.createStatement()) {
-      stmt.execute(truncate);
+      stmt.execute(deletes.toString());
     }
   }
 
@@ -95,8 +194,9 @@ public class PgContainer implements AutoCloseable {
 
   private PgContainer(boolean requireFresh) {
     pooled = !requireFresh;
-    pgContainer = pooled ? acquire() : containerSupplier();
-    jdbcUrl = pgContainer.getJdbcUrl().replaceFirst("/[^/]+$", "/" + DB_NAME);
+    pgContainer = pooled ? acquire() : containerSupplier(false);
+    var database = pooled ? POOLED_DB_NAME : FRESH_DB_NAME;
+    jdbcUrl = pgContainer.getJdbcUrl().replaceFirst("/[^/]+$", "/" + database);
   }
 
   public static PgContainer createFresh() {

--- a/transact/src/test/java/dev/dbos/transact/utils/PgContainer.java
+++ b/transact/src/test/java/dev/dbos/transact/utils/PgContainer.java
@@ -124,21 +124,42 @@ public class PgContainer implements AutoCloseable {
           DriverManager.getConnection(jdbcUrl, container.getUsername(), container.getPassword())) {
         resetDbosTables(conn);
       } catch (SQLException e) {
+        // The container came out of the pool, so nothing else is holding it: dropping it here
+        // without closing it would leave it running and unreachable for the rest of the run.
+        closeQuietly(container);
         throw new RuntimeException(e);
       }
       return container;
     }
-    container = containerSupplier(true);
-    var jdbcUrl = container.getJdbcUrl().replaceFirst("/[^/]+$", "/" + POOLED_DB_NAME);
+    var fresh = containerSupplier(true);
+    var jdbcUrl = fresh.getJdbcUrl().replaceFirst("/[^/]+$", "/" + POOLED_DB_NAME);
 
-    // The image arrives migrated, so this is normally a no-op -- every SDK gates on
-    // `current < latest`. It is kept rather than deleted because it is what makes the pinned image
-    // tag a performance decision rather than a correctness one: if this build's migrations run
-    // ahead
-    // of the image, this applies the tail instead of failing.
-    MigrationManager.runMigrations(
-        jdbcUrl, container.getUsername(), container.getPassword(), "dbos", true);
-    return container;
+    try {
+      // The image arrives migrated, so this is normally a no-op -- every SDK gates on
+      // `current < latest`. It is kept rather than deleted because it is what makes the pinned
+      // image tag a performance decision rather than a correctness one: if this build's migrations
+      // run ahead of the image, this applies the tail instead of failing.
+      MigrationManager.runMigrations(
+          jdbcUrl, fresh.getUsername(), fresh.getPassword(), "dbos", true);
+    } catch (RuntimeException e) {
+      // A container that fails to prepare has been started but never handed to anyone, and the
+      // caller is about to see an exception rather than an AutoCloseable. Left alone it stays up
+      // for the rest of the run, and since the next test finds the pool empty and starts another,
+      // one broken image turns into as many orphaned containers as there are tests. That is how a
+      // wrong pg_hba.conf in a prebaked image produced 181 of them.
+      closeQuietly(fresh);
+      throw e;
+    }
+    return fresh;
+  }
+
+  private static void closeQuietly(JdbcDatabaseContainer<?> container) {
+    try {
+      container.close();
+    } catch (RuntimeException suppressed) {
+      // Reporting why the database could not be prepared matters more than reporting that its
+      // container also would not stop.
+    }
   }
 
   static void release(JdbcDatabaseContainer<?> c) {


### PR DESCRIPTION
Two costs, both CockroachDB's, both paid on every pooled test database.

**Starting one** ran the whole migration corpus — about a minute of online
schema changes. The pool now starts from images whose DBOS schema is already
migrated: `ghcr.io/dbos-inc/dbos-test-{postgres,cockroach}`, published from
dbos-ctl and pinned here to a migration version, so a migration landing there
cannot change what this suite runs against without a commit here saying so.

**Resetting one** ran `TRUNCATE`, which CockroachDB also implements as a schema
change, so it prices like `CREATE INDEX` however few rows a table holds —
measured at 1.16s against 0.05s for the equivalent deletes, roughly 900 times a
run. The reset is now `DELETE`, over a table list read from the catalogue rather
than hard-coded, so a migration that adds a table cannot silently leave it
uncleaned. That half is taken from #473, which was abandoned rather than
rejected.

## Measured on CI

[This branch](https://github.com/dbos-inc/dbos-transact-java/actions/runs/33779764382)
against [the last PR run on main](https://github.com/dbos-inc/dbos-transact-java/actions/runs/33563766739),
both green:

| job | before | after | change |
|---|---|---|---|
| **test-crdb** | **1403s** (23m23s) | **779s** (12m59s) | **−624s, −44%** |
| test (17, temurin) | 672s | 671s | −1s |
| test (17, oracle) | 661s | 646s | −15s |
| test (21, temurin) | 596s | 632s | +36s |
| test (21, oracle) | 566s | 565s | −1s |
| test (25, temurin) | 609s | 581s | −28s |
| test (25, oracle) | 562s | 558s | −4s |

**Whole-run wall clock: 23m → 13m**, since `test-crdb` is the critical path.

PostgreSQL is a wash, and that is the expected result rather than a
disappointing one: its `TRUNCATE` was never expensive and its migration is under
a second, so there was nothing there to win. The spread of −28s to +36s across
six jobs is run-to-run noise. What matters is that it did not regress.

## The pool is kept deliberately

An earlier attempt (#479) gave every test its own container instead. CI rejected
it: `test-crdb` went from 23m23s to 30m *while running at four times the
parallelism*, because container creation cost more than the reset it replaced.
Containers are worth pooling. What was worth removing is what the pool did to
them.

## Parallelism is left alone

Still `CrdbParallelExecutionConfigurationStrategy` from `main`, which gives
CockroachDB 2 on an 8-core machine and 1 below that — so **1** on a 4-core CI
runner. The 779s above is what one CockroachDB test at a time now costs.

Raising it is the obvious next lever and is now much more affordable, since
concurrent containers no longer each migrate. It is left out so this change is
one variable and the numbers above are readable — and because parallelism is
what made the from-empty migration tests time out when tried alongside per-test
containers, which is the same pressure that required the timeout in the third
commit here.

## Tests that must start empty are untouched

`createFresh()`, `getPG()` and `getCRDB()` still hand out stock images with no
DBOS schema in them — `MigrationManagerTest`, `CustomSchemaTest`,
`JdbcStepFactoryInitTest` and `CockroachMigrationTest`. They exist to watch a
schema being built, and an image arriving with one built would test nothing.

`CockroachMigrationTest` gains a five-minute class timeout. Every test in it
migrates a stock CockroachDB container from empty, which is tens of seconds even
idle, and the suite-wide two-minute default was a coin toss against that. It
became marginal *because* of this change: pooled containers no longer migrate,
so the suite runs denser and the tests still doing the slow thing get less of the
runner. Raised rather than removed, so a genuine hang still fails.

## Two testcontainers traps, and one leak

PostgreSQL's default wait strategy looks for "ready to accept connections"
*twice*, because a container that initialises itself starts the server once for
initdb and again to serve. A prebaked image logs it once, so every container
would wait out its startup timeout while being ready the whole time.

CockroachDB has to be told where its store is — a prebaked image keeps it
outside the default location so a container that forgets to ask starts an empty
node rather than appearing to work. Setting a password would also make
`CockroachContainer.configure()` replace the command and silently drop both the
store path and `--insecure`.

The second commit fixes a leak that predates this branch: `acquire()` started a
container and threw without closing it if preparing the database failed. The
exception escapes the constructor, so the field is never assigned, `@AutoClose`
never registers, and the container stays up unreachable while the next test
starts another. One broken image therefore cost one container *per test* — a
prebaked image that refused connections produced 181 orphans before the run was
killed, and the machine rather than the assertion is what reported it.

## Requires

dbos-ctl#23, merged and force-republished. Before that these images refused
every TCP connection.

## Known flake, untouched

`DynamicQueuesTest.testLimiter()` failed once on the CockroachDB leg
(`Diff: 1.452` against a hard-coded `waveTolerance = 1.0`) and passed on the
re-run. A one-second budget for a scheduling assertion is tight on a loaded
four-core runner. Loosening a timing test to make an unrelated change green
should be its own decision, so it is left alone here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)