### PR TITLE
Stop two flaky tests measuring latency instead of behaviour

### DIFF
--- a/transact/src/test/java/dev/dbos/transact/database/ChaosTest.java
+++ b/transact/src/test/java/dev/dbos/transact/database/ChaosTest.java
@@ -12,6 +12,7 @@ import dev.dbos.transact.workflow.Workflow;
 
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -38,6 +39,8 @@ interface ChaosService {
 }
 
 class ChaosServiceImpl implements ChaosService {
+
+  private static final Logger logger = LoggerFactory.getLogger(ChaosServiceImpl.class);
 
   private final DBOS dbos;
   private final DataSource dataSource;
@@ -95,6 +98,18 @@ class ChaosServiceImpl implements ChaosService {
     return "Part2" + v1;
   }
 
+  // pg_backend_pid() only exempts the caller's own connection, so two causeChaos() calls
+  // overlapping on the same database are each a valid target for the other: the parent
+  // workflow and the child it starts both call this. Losing the chaos connection to a peer
+  // is the disruption this test exists to cause, not a failure of it, so the SQLSTATEs that
+  // mean "this connection was terminated" are tolerated rather than reported.
+  private static final Set<String> TERMINATED_SQL_STATES =
+      Set.of(
+          "57P01", // admin_shutdown: terminating connection due to administrator command
+          "08006", // connection_failure
+          "08003", // connection_does_not_exist
+          "08001"); // sqlclient_unable_to_establish_sqlconnection
+
   static void causeChaos(DataSource ds) {
     try (var conn = ds.getConnection();
         var st = conn.createStatement()) {
@@ -107,8 +122,21 @@ class ChaosServiceImpl implements ChaosService {
               AND datname = current_database();
         """);
     } catch (SQLException e) {
-      throw new RuntimeException("Could not cause chaos, credentials insufficient?", e);
+      if (wasTerminated(e)) {
+        logger.info("causeChaos lost its own connection to a concurrent chaos call", e);
+        return;
+      }
+      throw new RuntimeException("Could not cause chaos", e);
     }
+  }
+
+  private static boolean wasTerminated(SQLException e) {
+    for (Throwable t = e; t != null; t = t.getCause()) {
+      if (t instanceof SQLException sqle && TERMINATED_SQL_STATES.contains(sqle.getSQLState())) {
+        return true;
+      }
+    }
+    return false;
   }
 }
 

--- a/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/DynamicQueuesTest.java
@@ -2,6 +2,7 @@ package dev.dbos.transact.queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -682,43 +683,44 @@ public class DynamicQueuesTest {
     }
 
     for (WorkflowHandle<Double, ?> h : handles) {
-      double result = h.getResult();
-      logger.info(String.valueOf(result));
-      times.add(result);
+      h.getResult();
+      Long startedAt = h.getStatus().startedAtEpochMs();
+      assertNotNull(startedAt, "workflow " + h.workflowId() + " has no start time");
+      times.add(startedAt / 1000.0);
     }
-
-    double waveTolerance = 1.0;
-    for (int wave = 0; wave < numWaves; wave++) {
-      for (int i = wave * limit; i < (wave + 1) * limit - 1; i++) {
-        double diff = times.get(i + 1) - times.get(i);
-        logger.info(String.format("Wave %d, Task %d-%d: Time diff %.3f", wave, i, i + 1, diff));
-        assertTrue(
-            diff < waveTolerance,
-            String.format(
-                "Wave %d: Tasks %d and %d should start close together. Diff: %.3f",
-                wave, i, i + 1, diff));
-      }
-    }
-    logger.info("Verified intra-wave timing.");
 
     double periodTolerance = 0.5;
-    for (int wave = 0; wave < numWaves - 1; wave++) {
-      double startOfNextWave = times.get(limit * (wave + 1));
-      double startOfCurrentWave = times.get(limit * wave);
-      double gap = startOfNextWave - startOfCurrentWave;
-      logger.info(String.format("Gap between Wave %d and %d: %.3f", wave, wave + 1, gap));
-      assertTrue(
-          gap > periodSec - periodTolerance,
-          String.format(
-              "Gap between wave %d and %d should be at least %.3f. Actual: %.3f",
-              wave, wave + 1, periodSec - periodTolerance, gap));
-      assertTrue(
-          gap < periodSec + periodTolerance,
-          String.format(
-              "Gap between wave %d and %d should be at most %.3f. Actual: %.3f",
-              wave, wave + 1, periodSec + periodTolerance, gap));
-    }
 
+    // The limiter is a sliding window: it refuses to dequeue while `limit` workflows on the queue
+    // have started within the last period. Task i and task i + limit are therefore at least a
+    // period apart, because otherwise limit + 1 starts would fit in one window. This is a lower
+    // bound, so a slow database pushes the gap away from the boundary rather than into it —
+    // unlike an upper bound on how close consecutive tasks start, which measures the per-workflow
+    // round trip rather than the limiter, and which CockroachDB was slow enough to miss.
+    for (int i = 0; i + limit < numTasks; i++) {
+      double diff = times.get(i + limit) - times.get(i);
+      logger.info(String.format("Tasks %d and %d: Time diff %.3f", i, i + limit, diff));
+      assertTrue(
+          diff > periodSec - periodTolerance,
+          String.format(
+              "Only %d tasks may start per %.3fs, so tasks %d and %d should start at least %.3fs"
+                  + " apart. Actual: %.3f",
+              limit, periodSec, i, i + limit, periodSec - periodTolerance, diff));
+    }
+    logger.info("Verified rate limit spacing.");
+
+    // ... and the limiter must not throttle harder than it is configured to. Each wave after the
+    // first costs a period, so the starts span numWaves - 1 periods, plus however long it takes
+    // to dispatch and run the tasks within a wave. Two further periods of allowance for that
+    // still catches a limiter releasing half its configured rate.
+    double maxSpan = (numWaves + 1) * periodSec;
+    double span = times.get(numTasks - 1) - times.get(0);
+    logger.info(String.format("Span of all %d starts: %.3f", numTasks, span));
+    assertTrue(
+        span < maxSpan,
+        String.format(
+            "%d tasks at %d per %.3fs should all start within %.3fs. Actual: %.3f",
+            numTasks, limit, periodSec, maxSpan, span));
     for (WorkflowHandle<Double, ?> h : handles) {
       assertEquals(WorkflowState.SUCCESS, h.getStatus().status());
     }

--- a/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
+++ b/transact/src/test/java/dev/dbos/transact/queue/StaticQueuesTest.java
@@ -1,6 +1,7 @@
 package dev.dbos.transact.queue;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -372,45 +373,44 @@ public class StaticQueuesTest {
     }
 
     for (WorkflowHandle<Double, ?> h : handles) {
-      double result = h.getResult();
-      logger.info(String.valueOf(result));
-      times.add(result);
+      h.getResult();
+      Long startedAt = h.getStatus().startedAtEpochMs();
+      assertNotNull(startedAt, "workflow " + h.workflowId() + " has no start time");
+      times.add(startedAt / 1000.0);
     }
 
-    // CockroachDB's slower transaction throughput can spread tasks across a wider window
-    double waveTolerance = PgContainer.USE_COCKROACH_DB ? 3.0 : 1.0;
-    for (int wave = 0; wave < numWaves; wave++) {
-      for (int i = wave * limit; i < (wave + 1) * limit - 1; i++) {
-        double diff = times.get(i + 1) - times.get(i);
-        logger.info(String.format("Wave %d, Task %d-%d: Time diff %.3f", wave, i, i + 1, diff));
-        assertTrue(
-            diff < waveTolerance,
-            String.format(
-                "Wave %d: Tasks %d and %d should start close together. Diff: %.3f",
-                wave, i, i + 1, diff));
-      }
-    }
-    logger.info("Verified intra-wave timing.");
+    double periodTolerance = 0.5;
 
-    // CockroachDB's slower transaction throughput can widen the inter-wave gap as well
-    double periodTolerance = PgContainer.USE_COCKROACH_DB ? 1.0 : 0.5;
-    for (int wave = 0; wave < numWaves - 1; wave++) {
-      double startOfNextWave = times.get(limit * (wave + 1));
-      double startOfCurrentWave = times.get(limit * wave);
-      double gap = startOfNextWave - startOfCurrentWave;
-      logger.info(String.format("Gap between Wave %d and %d: %.3f", wave, wave + 1, gap));
+    // The limiter is a sliding window: it refuses to dequeue while `limit` workflows on the queue
+    // have started within the last period. Task i and task i + limit are therefore at least a
+    // period apart, because otherwise limit + 1 starts would fit in one window. This is a lower
+    // bound, so a slow database pushes the gap away from the boundary rather than into it —
+    // unlike an upper bound on how close consecutive tasks start, which measures the per-workflow
+    // round trip rather than the limiter, and which CockroachDB was slow enough to miss.
+    for (int i = 0; i + limit < numTasks; i++) {
+      double diff = times.get(i + limit) - times.get(i);
+      logger.info(String.format("Tasks %d and %d: Time diff %.3f", i, i + limit, diff));
       assertTrue(
-          gap > periodSec - periodTolerance,
+          diff > periodSec - periodTolerance,
           String.format(
-              "Gap between wave %d and %d should be at least %.3f. Actual: %.3f",
-              wave, wave + 1, periodSec - periodTolerance, gap));
-      assertTrue(
-          gap < periodSec + periodTolerance,
-          String.format(
-              "Gap between wave %d and %d should be at most %.3f. Actual: %.3f",
-              wave, wave + 1, periodSec + periodTolerance, gap));
+              "Only %d tasks may start per %.3fs, so tasks %d and %d should start at least %.3fs"
+                  + " apart. Actual: %.3f",
+              limit, periodSec, i, i + limit, periodSec - periodTolerance, diff));
     }
+    logger.info("Verified rate limit spacing.");
 
+    // ... and the limiter must not throttle harder than it is configured to. Each wave after the
+    // first costs a period, so the starts span numWaves - 1 periods, plus however long it takes
+    // to dispatch and run the tasks within a wave. Two further periods of allowance for that
+    // still catches a limiter releasing half its configured rate.
+    double maxSpan = (numWaves + 1) * periodSec;
+    double span = times.get(numTasks - 1) - times.get(0);
+    logger.info(String.format("Span of all %d starts: %.3f", numTasks, span));
+    assertTrue(
+        span < maxSpan,
+        String.format(
+            "%d tasks at %d per %.3fs should all start within %.3fs. Actual: %.3f",
+            numTasks, limit, periodSec, maxSpan, span));
     for (WorkflowHandle<Double, ?> h : handles) {
       assertEquals(WorkflowState.SUCCESS, h.getStatus().status());
     }


### PR DESCRIPTION
Fixes #481 and #474. Both tests failed on assertions that were really measuring database latency, so they went red on whichever job happened to be slowest rather than on anything being wrong.

## ChaosTest (#481)

`causeChaos()` terminates every backend on the database except its own, and `pg_backend_pid()` only exempts the caller. `runChildWf` calls it, starts a child workflow that calls it too, then calls it again — parent and child are different backends on the same database, so each is a valid target for the other. When the calls overlap, one is terminated mid-statement and the test fails with:

```
java.lang.RuntimeException: Could not cause chaos, credentials insufficient?
Caused by: org.postgresql.util.PSQLException:
    FATAL: terminating connection due to administrator command
```

Nothing is wrong with the credentials, and that message sends whoever hits this looking at roles and `pg_hba.conf`.

Losing the chaos connection to a peer chaos call is the disruption this test exists to cause, so the SQLSTATEs that mean "this connection was terminated" (`57P01`, `08006`, `08003`, `08001`, checked down the cause chain) are now tolerated and logged. Anything else still throws, with a message that no longer guesses at a cause.

## testLimiter (#474)

The queue is registered with `rateLimit(5, 1.8s)`, `concurrency(1)`, `workerConcurrency(1)`, so a wave's five tasks run one at a time. The intra-wave assertion required each to start within `waveTolerance = 1.0s` of the previous one — which measures a dequeue → run → complete round trip against the system database, not the limiter. Only 300ms separated that ceiling from the inter-wave floor of 1.3s, and CockroachDB's commit latency was enough to close it (`Diff: 1.452`).

`StaticQueuesTest` carries a copy of the same test, and had already been given CockroachDB tolerances (`waveTolerance = 3.0`, `periodTolerance = 1.0`) that put the intra-wave ceiling *above* the inter-wave floor, so on CockroachDB that check no longer distinguished a wave from the next one. Both copies are changed here.

Both now assert the limiter's own guarantee, measured on the `started_at` it stamps at dequeue rather than on a clock read inside the workflow body, so dispatch latency is not in the measurement at all:

- **Lower bound.** The limiter refuses to dequeue while `limit` workflows have started within the last period, so `limit + 1` starts cannot fit in one window and task `i` and task `i + limit` are at least a period apart. This is a lower bound, so a slow database pushes the gap *away* from the boundary rather than into it.
- **Upper bound.** All the starts span less than `(numWaves + 1) * period`, which keeps the other direction — a limiter releasing half its configured rate still fails.

Measured on Postgres, every gap lands at 1.802–1.814s against a 1.3s floor, and the span is 3.75s against a 7.2s bound.

## Not addressed

#477 (`CancelResumeRaceTest.activeIdReleasedBeforeOutcomeWriteTest`) is untouched. It did not reproduce in 24 runs under CPU load, and the issue's hypothesis — the poller dispatching once more while the stale outcome write is parked — does not survive a read of the dequeue path: `startQueuedWorkflows` only selects `ENQUEUED` rows and claims them with an atomic `UPDATE ... WHERE status = 'ENQUEUED'`, and `getResult` only polls. The one path that returns a dispatched workflow to `ENQUEUED` is the launch-time recovery sweep via `clearQueueAssignment`, but its `created_at <= endTime` bound would need the workflow to be created in the same millisecond as launch; the measured gap is 178ms. Left open rather than relaxed, so a real dispatch bug is not papered over.